### PR TITLE
Add codehilite markdown extension to mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ markdown_extensions:
   - toc:
       permalink: True
       separator: "_"
+  - codehilite
 nav:
   - 'Home': 'index.md'
   - 'Getting started': 'getting-started.md'


### PR DESCRIPTION
There are several code blocks annotated with language tags, but no syntax highlighting is used since the "codehilite" extension is not enabled.