### PR TITLE
Return error when sending with no senders created

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -50,6 +50,10 @@ func New(logger *log.Logger, serviceURLs ...string) (*ServiceRouter, error) {
 
 // Send sends the specified message using the routers underlying services
 func (router *ServiceRouter) Send(message string, params *t.Params) []error {
+	if router == nil {
+		return []error{fmt.Errorf("error sending message: no senders")}
+	}
+
 	serviceCount := len(router.services)
 	errors := make([]error, serviceCount)
 	results := make(chan error, serviceCount)


### PR DESCRIPTION
Otherwise the method would panic trying to get the length of services..

Having no senders is only possible if you didn't check the errors from `CreateSender()` but I think avoiding a panic is whortwhile anyway.