### PR TITLE
fix(docker): add CA cert bundle to docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
         with:
           username: '${{ secrets.DOCKER_USER }}'
           password: '${{ secrets.DOCKER_PASSWORD }}'
+ 
+      - name: Fetch CA cert bundle
+        run: curl -o ca-certificates.pem https://curl.haxx.se/ca/cacert.pem
 
       - name: Execute goreleaser
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 
+COPY ca-certificates.pem /etc/ssl/certs/
 COPY shoutrrr /
 
 ENTRYPOINT ["./shoutrrr"]


### PR DESCRIPTION
Includes the CA cert bundle from cURL into the docker image.  

Fixes #47 