### PR TITLE
fix(services/teams): parsing 'teams://' URLs incorrectly

### DIFF
--- a/pkg/services/teams/teams_config.go
+++ b/pkg/services/teams/teams_config.go
@@ -1,7 +1,9 @@
 package teams
 
 import (
+	"fmt"
 	"net/url"
+	"path"
 
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 )
@@ -25,10 +27,9 @@ func (config *Config) GetURL() *url.URL {
 
 // SetURL updates a ServiceConfig from a URL representation of it's field values
 func (config *Config) SetURL(url *url.URL) error {
-
-	tokenA := url.User.Username()
-	tokenB, _ := url.User.Password()
-	tokenC := url.Hostname()
+	tokenA := fmt.Sprintf("%v@%v", url.User.Username(), url.Hostname())
+	_, tokenB := path.Split(path.Dir(url.Path))
+	tokenC := path.Base(url.Path)
 
 	config.Token = Token{
 		A: tokenA,


### PR DESCRIPTION
Currently the teams service is parsing the teams:// URLs incorrectly (ref [docs](https://github.com/containrrr/shoutrrr/blob/master/docs/services/teams.md)).

- token A has the shape `<UUID>@<UUID>`
- token B has the shape `<UUID>`
- token C has the shape `<UUID>`

Translated to the teams:// URL scheme, that results in `teams://<UUID>@<UUID>/UUID/UUID`

This means that:
- token A is the concatenation of userinfo and hostname with an '@' in between when parsed using url.URL.
- token B is the dir with the slash removed
- token C is the "file" when treating url.URL.Path as a file path