### PR TITLE
Correct the ID part of webhook

### DIFF
--- a/docs/services/discord.md
+++ b/docs/services/discord.md
@@ -29,9 +29,9 @@ The shoutrrr service URL should look like this:
 ```
 https://discordapp.com/api/webhooks/693853386302554172/W3dE2OZz4C13_4z_uHfDOoC7BqTW288s-z1ykqI0iJnY_HjRqMGO8Sc7YDqvf_KVKjhJ
                                     └────────────────┘ └──────────────────────────────────────────────────────────────────┘
-                                          channel                                      token
+                                        webhook id                                    token
 
 discord://W3dE2OZz4C13_4z_uHfDOoC7BqTW288s-z1ykqI0iJnY_HjRqMGO8Sc7YDqvf_KVKjhJ@693853386302554172
           └──────────────────────────────────────────────────────────────────┘ └────────────────┘
-                                          token                                      channel
+                                          token                                    webhook id
 ```

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -4,7 +4,7 @@ Click on the service for a more thorough explanation.
 
 | Service                           | URL format                                                                                                                                      |
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Discord](./discord.md)           | *discord://__`token`__@__`channel`__*                                                                                                           |
+| [Discord](./discord.md)           | *discord://__`token`__@__`id`__*                                                                                                           |
 | [Telegram](./not-documented.md)   | *telegram://__`token`__@telegram?channels=__`channel-1`__[,__`channel-2`__,...]*                                                                |
 | [Pushover](./pushover.md)         | *pushover://shoutrrr:__`apiToken`__@__`userKey`__/?devices=__`device1`__[,__`device2`__, ...]*                                                  |
 | [Slack](./not-documented.md)      | *slack://[__`botname`__@]__`token-a`__/__`token-b`__/__`token-c`__*                                                                             |


### PR DESCRIPTION
The ID is not actually the channel, it's the ID of the webhook – all webhooks are technically bot users under the hood, and this is their user ID (snowflake)