### PR TITLE
feat(smtp): add support for implicit TLS

### DIFF
--- a/pkg/services/smtp/smtp_config.go
+++ b/pkg/services/smtp/smtp_config.go
@@ -13,17 +13,18 @@ import (
 
 // Config is the configuration needed to send e-mail notifications over SMTP
 type Config struct {
-	Host        string   `desc:"SMTP server hostname or IP address"`
-	Username    string   `desc:"authentication username"`
-	Password    string   `desc:"authentication password or hash"`
-	Port        uint16   `desc:"SMTP server port, common ones are 25, 465, 587 or 2525" default:"25"`
-	FromAddress string   `desc:"e-mail address that the mail are sent from"`
-	FromName    string   `desc:"name of the sender" optional:"yes"`
-	ToAddresses []string `desc:"list of recipient e-mails separated by \",\" (comma)"`
-	Subject     string   `desc:"the subject of the sent mail" param:"subject" default:"Shoutrrr Notification"`
-	Auth        authType `desc:"SMTP authentication method"`
-	UseStartTLS bool     `desc:"attempt to use SMTP StartTLS encryption" default:"Yes"`
-	UseHTML     bool     `desc:"whether the message being sent is in HTML" default:"No"`
+	Host        string    `desc:"SMTP server hostname or IP address"`
+	Username    string    `desc:"authentication username"`
+	Password    string    `desc:"authentication password or hash"`
+	Port        uint16    `desc:"SMTP server port, common ones are 25, 465, 587 or 2525" default:"25"`
+	FromAddress string    `desc:"e-mail address that the mail are sent from"`
+	FromName    string    `desc:"name of the sender" optional:"yes"`
+	ToAddresses []string  `desc:"list of recipient e-mails separated by \",\" (comma)"`
+	Subject     string    `desc:"the subject of the sent mail" param:"subject" default:"Shoutrrr Notification"`
+	Auth        authType  `desc:"SMTP authentication method"`
+	Encryption  encMethod `desc:"Encryption method" default:"Auto"`
+	UseStartTLS bool      `desc:"attempt to use SMTP StartTLS encryption" default:"Yes"`
+	UseHTML     bool      `desc:"whether the message being sent is in HTML" default:"No"`
 }
 
 // GetURL returns a URL representation of it's current field values
@@ -79,6 +80,7 @@ func (config *Config) QueryFields() []string {
 		"auth",
 		"subject",
 		"startTls",
+		"encryption",
 		"useHTML",
 	}
 }
@@ -98,6 +100,8 @@ func (config *Config) Get(key string) (string, error) {
 		return config.Subject, nil
 	case "starttls":
 		return format.PrintBool(config.UseStartTLS), nil
+	case "encryption":
+		return config.Encryption.String(), nil
 	case "usehtml":
 		return format.PrintBool(config.UseHTML), nil
 	}
@@ -119,6 +123,8 @@ func (config *Config) Set(key string, value string) error {
 		config.Subject = value
 	case "starttls":
 		config.UseStartTLS, _ = format.ParseBool(value, true)
+	case "encryption":
+		config.Encryption = parseEncryption(value)
 	case "usehtml":
 		config.UseHTML, _ = format.ParseBool(value, false)
 	default:
@@ -130,7 +136,8 @@ func (config *Config) Set(key string, value string) error {
 // Enums returns the fields that should use a corresponding EnumFormatter to Print/Parse their values
 func (config Config) Enums() map[string]types.EnumFormatter {
 	return map[string]types.EnumFormatter{
-		"Auth": authTypes.Enum,
+		"Auth":       authTypes.Enum,
+		"Encryption": encMethods.Enum,
 	}
 }
 

--- a/pkg/services/smtp/smtp_encmethod.go
+++ b/pkg/services/smtp/smtp_encmethod.go
@@ -1,0 +1,53 @@
+package smtp
+
+import (
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
+)
+
+type encMethod int
+
+type encMethodVals struct {
+	None        encMethod
+	ExplicitTLS encMethod
+	ImplicitTLS encMethod
+	Auto        encMethod
+
+	Enum types.EnumFormatter
+}
+
+var encMethods = &encMethodVals{
+	None:        0,
+	ExplicitTLS: 1,
+	ImplicitTLS: 2,
+	Auto:        3,
+
+	Enum: format.CreateEnumFormatter(
+		[]string{
+			"None",
+			"ExplicitTLS",
+			"ImplicitTLS",
+			"Auto",
+		}),
+}
+
+func (at encMethod) String() string {
+	return encMethods.Enum.Print(int(at))
+}
+
+func parseEncryption(s string) encMethod {
+	return encMethod(encMethods.Enum.Parse(s))
+}
+
+func useImplicitTLS(encryption encMethod, port uint16) bool {
+	switch encryption {
+	case encMethods.ImplicitTLS:
+		return true
+	case encMethods.Auto:
+		return port == ImplicitTLSPort
+	default:
+		return false
+	}
+}
+
+const ImplicitTLSPort = 465

--- a/pkg/services/smtp/smtp_test.go
+++ b/pkg/services/smtp/smtp_test.go
@@ -42,7 +42,7 @@ var _ = Describe("the SMTP service", func() {
 	})
 	When("parsing the configuration URL", func() {
 		It("should be identical after de-/serialization", func() {
-			testURL := "smtp://user:password@example.com:2225/?fromAddress=sender@example.com&fromName=Sender&toAddresses=rec1@example.com,rec2@example.com&auth=None&subject=Subject&startTls=No&useHTML=No"
+			testURL := "smtp://user:password@example.com:2225/?fromAddress=sender@example.com&fromName=Sender&toAddresses=rec1@example.com,rec2@example.com&auth=None&subject=Subject&startTls=No&encryption=Auto&useHTML=No"
 
 			url, err := url.Parse(testURL)
 			Expect(err).NotTo(HaveOccurred(), "parsing")
@@ -88,8 +88,8 @@ var _ = Describe("the SMTP service", func() {
 		testutils.TestConfigGetInvalidQueryValue(&Config{})
 		testutils.TestConfigSetInvalidQueryValue(&Config{}, "smtp://example.com/?fromAddress=s@example.com&toAddresses=r@example.com&foo=bar")
 
-		testutils.TestConfigGetEnumsCount(&Config{}, 1)
-		testutils.TestConfigGetFieldsCount(&Config{}, 7)
+		testutils.TestConfigGetEnumsCount(&Config{}, 2)
+		testutils.TestConfigGetFieldsCount(&Config{}, 8)
 	})
 
 	When("the service is not configured correctly", func() {


### PR DESCRIPTION
Add SMTPS (implicit TLS) support for SMTP.
Use implicit TLS by default if port is set to `465`, configurable by setting the `Encryption` field.

Fixes #68 