### PR TITLE
do not rewrite channel name without hashes

### DIFF
--- a/pkg/services/rocketchat/rocketchat.go
+++ b/pkg/services/rocketchat/rocketchat.go
@@ -3,9 +3,11 @@ package rocketchat
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
+
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	"github.com/containrrr/shoutrrr/pkg/types"
 )
@@ -36,10 +38,12 @@ func (service *Service) Send(message string, params *types.Params) error {
 	json, _ := CreateJSONPayload(config, message, params)
 	res, err = http.Post(apiURL, "application/json", bytes.NewReader(json))
 	if err != nil {
-		return fmt.Errorf("Error while posting to URL: %v\nHOST: %s\nPORT: %s\n", err, config.Host, config.Port)
+		return fmt.Errorf("Error while posting to URL: %v\nHOST: %s\nPORT: %s", err, config.Host, config.Port)
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to send notification to service, response status code %s", res.Status)
+		resBody, _ := ioutil.ReadAll(res.Body)
+		return fmt.Errorf("notification failed: %d %s", res.StatusCode, resBody)
 	}
 	return err
 }
@@ -51,4 +55,3 @@ func buildURL(config *Config) string {
 		return fmt.Sprintf("https://%s/hooks/%s/%s", config.Host, config.TokenA, config.TokenB)
 	}
 }
-

--- a/pkg/services/rocketchat/rocketchat_config.go
+++ b/pkg/services/rocketchat/rocketchat_config.go
@@ -50,7 +50,7 @@ func (config *Config) SetURL(serviceURL *url.URL) error {
 	config.TokenB = path[2]
 	if len(path) > 3 {
 		if serviceURL.Fragment != "" {
-			config.Channel = "#" + strings.TrimPrefix(serviceURL.Fragment, "#")
+			config.Channel = "#" + serviceURL.Fragment
 		} else if !strings.HasPrefix(path[3], "@") {
 			config.Channel = "#" + path[3]
 		} else {


### PR DESCRIPTION
I removed TrimPrefix as discussed here: [https://github.com/containrrr/shoutrrr/pull/83#discussion_r523826228](https://github.com/containrrr/shoutrrr/pull/83#discussion_r523826228)

I added logic to print the http response body if response status code is different then 200. Errors returned by the server are now visible, for example:
`error invoking send: notification failed: 404 {"success":false,"error":"Invalid integration id or token provided."}%    `