### PR TITLE
added errocheck to avoid segfault due to nil http.response *service.mattermost

### DIFF
--- a/pkg/services/mattermost/mattermost.go
+++ b/pkg/services/mattermost/mattermost.go
@@ -34,7 +34,9 @@ func (service *Service) Send(message string, params *types.Params) error {
 	apiURL := buildURL(config)
 	json, _ := CreateJSONPayload(config, message, params)
 	res, err := http.Post(apiURL, "application/json", bytes.NewReader(json))
-
+	if err != nil {
+		return err
+	}
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to send notification to service, response status code %s", res.Status)
 	}


### PR DESCRIPTION
Fixes: https://github.com/containrrr/shoutrrr/issues/93

- Before:

```
kubectl logs pod/kured-kj4mv -n kube-system
time="2020-12-09T19:12:59Z" level=warning msg="Deprecated flag(s). Please use --notify-url flag instead."
time="2020-12-09T19:12:59Z" level=info msg="Kubernetes Reboot Daemon: master-da7f425"
time="2020-12-09T19:12:59Z" level=info msg="Node ID: minikube-m02"
time="2020-12-09T19:12:59Z" level=info msg="Lock Annotation: kube-system/kured:weave.works/kured-node-lock"
time="2020-12-09T19:12:59Z" level=info msg="Lock TTL not set, lock will remain until being released"
time="2020-12-09T19:12:59Z" level=info msg="Reboot Sentinel: /var/run/reboot-required every 20s"
time="2020-12-09T19:12:59Z" level=info msg="Blocking Pod Selectors: []"
time="2020-12-09T19:12:59Z" level=info msg="Reboot on: SunMonTueWedThuFriSat between 00:00 and 23:59 UTC"
time="2020-12-09T19:12:59Z" level=info msg="Holding lock"
time="2020-12-09T19:12:59Z" level=info msg="Uncordoning node minikube-m02"
time="2020-12-09T19:12:59Z" level=info msg="Releasing lock"
time="2020-12-09T19:13:21Z" level=info msg="Reboot required"
time="2020-12-09T19:13:21Z" level=info msg="Acquired reboot lock"
time="2020-12-09T19:13:21Z" level=info msg="Draining node minikube-m02"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x13a776a]

goroutine 37 [running]:
github.com/containrrr/shoutrrr/pkg/services/mattermost.(*Service).Send(0xc00080d280, 0xc00044e6c0, 0x1a, 0xc000182c20, 0xc00080d280, 0x0)
	/home/user/go/pkg/mod/github.com/containrrr/shoutrrr@v0.0.0-20201124203606-785738593562/pkg/services/mattermost/mattermost.go:38 +0x20a
github.com/containrrr/shoutrrr.Send(0x7ffddf1b9bb5, 0x35, 0xc00044e6c0, 0x1a, 0x1, 0xc00044e6c0)
	/home/user/go/pkg/mod/github.com/containrrr/shoutrrr@v0.0.0-20201124203606-785738593562/shoutrrr.go:24 +0xd7
main.drain(0xc0001be420, 0xc000138000)
	/home/user/go/src/github.com/atighineanu/kured/cmd/kured/main.go:268 +0x49e
main.rebootAsRequired(0xc00003e02e, 0xc, 0xc000189380, 0x0)
	/home/user/go/src/github.com/atighineanu/kured/cmd/kured/main.go:378 +0x585
created by main.root
	/home/user/go/src/github.com/atighineanu/kured/cmd/kured/main.go:414 +0x64c

```

- After:

```
kubectl logs pod/kured-jh4rf -n kube-system
time="2020-12-09T20:12:37Z" level=warning msg="Deprecated flag(s). Please use --notify-url flag instead."
time="2020-12-09T20:12:37Z" level=info msg="Kubernetes Reboot Daemon: master-48f9154"
time="2020-12-09T20:12:37Z" level=info msg="Node ID: minikube-m02"
time="2020-12-09T20:12:37Z" level=info msg="Lock Annotation: kube-system/kured:weave.works/kured-node-lock"
time="2020-12-09T20:12:37Z" level=info msg="Lock TTL not set, lock will remain until being released"
time="2020-12-09T20:12:37Z" level=info msg="Reboot Sentinel: /var/run/reboot-required every 20s"
time="2020-12-09T20:12:37Z" level=info msg="Blocking Pod Selectors: []"
time="2020-12-09T20:12:37Z" level=info msg="Reboot on: SunMonTueWedThuFriSat between 00:00 and 23:59 UTC"
time="2020-12-09T20:12:37Z" level=info msg="Holding lock"
time="2020-12-09T20:12:37Z" level=info msg="Uncordoning node minikube-m02"
time="2020-12-09T20:12:37Z" level=info msg="Releasing lock"
time="2020-12-09T20:12:53Z" level=info msg="Reboot required"
time="2020-12-09T20:12:53Z" level=info msg="Acquired reboot lock"
time="2020-12-09T20:12:53Z" level=info msg="Draining node minikube-m02"
time="2020-12-09T20:13:23Z" level=warning msg="Error notifying: Post \"https://chat.holba.ch/hooks/<TOKEN>\": dial tcp: i/o timeout"
WARNING: ignoring DaemonSet-managed Pods: kube-system/kindnet-pllc8, kube-system/kube-proxy-jjkv8, kube-system/kured-jh4rf
time="2020-12-09T20:13:23Z" level=info msg="Commanding reboot for node: minikube-m02"
```


