### PR TITLE
feat(telegram): add more config options and tests

### DIFF
--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -5,7 +5,7 @@ Click on the service for a more thorough explanation.
 | Service                           | URL format                                                                                                                                      |
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Discord](./discord.md)           | *discord://__`token`__@__`id`__*                                                                                                           |
-| [Telegram](./not-documented.md)   | *telegram://__`token`__@telegram?channels=__`channel-1`__[,__`channel-2`__,...]*                                                                |
+| [Telegram](./telegram.md)         | *telegram://__`token`__@telegram?channels=__`channel-1`__[,__`channel-2`__,...]*                                                                |
 | [Pushover](./pushover.md)         | *pushover://shoutrrr:__`apiToken`__@__`userKey`__/?devices=__`device1`__[,__`device2`__, ...]*                                                  |
 | [Slack](./not-documented.md)      | *slack://[__`botname`__@]__`token-a`__/__`token-b`__/__`token-c`__*                                                                             |
 | [Email](./not-documented.md)      | *smtp://__`username`__:__`password`__@__`host`__:__`port`__/?fromAddress=__`fromAddress`__&toAddresses=__`recipient1`__[,__`recipient2`__,...]* |

--- a/docs/services/telegram.md
+++ b/docs/services/telegram.md
@@ -1,0 +1,18 @@
+# Telegram
+
+## URL Format
+
+*telegram://__`token`__@telegram?channels=__`channel-1`__[,__`channel-2`__,...]*
+
+## Getting a token for Telegram
+
+Talk to [the botfather](https://core.telegram.org/bots#6-botfather).
+
+## Optional parameters
+
+You can optionally specify the __`notification`__, __`parseMode`__ and __`preview`__ parameters in the URL:  
+*telegram://__`token`__@__`telegram`__/?channels=__`channel`__&notification=no&preview=false&parseMode=markDownv2*
+
+See [the telegram documentation](https://core.telegram.org/bots/api#sendmessage) for more information.
+
+__Note:__ `preview` and `notification` are inverted in regards to their API counterparts (`disable_web_page_preview` and `disable_notification`)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
       - Hangouts Chat: 'services/hangouts.md'
       - Pushover: 'services/pushover.md'
       - Teams: 'services/teams.md'
+      - Telegram: 'services/telegram.md'
       - Zulip Chat: 'services/zulip.md'
   - Advanced usage:
       - Proxy: 'proxy.md'

--- a/pkg/services/telegram/telegram.go
+++ b/pkg/services/telegram/telegram.go
@@ -43,7 +43,10 @@ func (service *Service) Send(message string, params *types.Params) error {
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
 func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
 	service.Logger.SetLogger(logger)
-	service.config = &Config{}
+	service.config = &Config{
+		Preview:      true,
+		Notification: true,
+	}
 	service.pkr = format.NewPropKeyResolver(service.config)
 	if err := service.config.setURL(&service.pkr, configURL); err != nil {
 		return err

--- a/pkg/services/telegram/telegram.go
+++ b/pkg/services/telegram/telegram.go
@@ -27,12 +27,17 @@ type Service struct {
 }
 
 // Send notification to Telegram
-func (service *Service) Send(message string, _ *types.Params) error {
+func (service *Service) Send(message string, params *types.Params) error {
 	if len(message) > maxlength {
 		return errors.New("message exceeds the max length")
 	}
 
-	return service.sendMessageForChatIDs(message)
+	config := *service.config
+	if err := service.pkr.UpdateConfigFromParams(&config, params); err != nil {
+		return err
+	}
+
+	return service.sendMessageForChatIDs(message, &config)
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
@@ -47,9 +52,9 @@ func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error
 	return nil
 }
 
-func (service *Service) sendMessageForChatIDs(message string) error {
+func (service *Service) sendMessageForChatIDs(message string, config *Config) error {
 	for _, channel := range service.config.Channels {
-		if err := sendMessageToAPI(message, channel, service.config.Token); err != nil {
+		if err := sendMessageToAPI(message, channel, config); err != nil {
 			return err
 		}
 	}
@@ -61,13 +66,12 @@ func (service *Service) GetConfig() *Config {
 	return service.config
 }
 
-func sendMessageToAPI(message string, channel string, apiToken string) error {
-	postURL := fmt.Sprintf("%s%s/sendMessage", apiBase, apiToken)
-	jsonData, err := json.Marshal(
-		JSON{
-			Text: message,
-			ID:   channel,
-		})
+func sendMessageToAPI(message string, channel string, config *Config) error {
+	postURL := fmt.Sprintf("%s%s/sendMessage", apiBase, config.Token)
+
+	payload := createSendMessagePayload(message, channel, config)
+
+	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/telegram/telegram_config.go
+++ b/pkg/services/telegram/telegram_config.go
@@ -10,13 +10,18 @@ import (
 
 // Config for use within the telegram plugin
 type Config struct {
-	Token    string
-	Channels []string `key:"channels"`
+	Token        string
+	Preview      bool      `key:"preview" default:"yes" desc:"If disabled, no web page preview will be displayed for URLs"`
+	Notification bool      `key:"notification" default:"yes" desc:"If disabled, sends message silently"`
+	ParseMode    parseMode `key:"parsemode" default:"None"`
+	Channels     []string  `key:"channels"`
 }
 
 // Enums returns the fields that should use a corresponding EnumFormatter to Print/Parse their values
 func (config *Config) Enums() map[string]types.EnumFormatter {
-	return map[string]types.EnumFormatter{}
+	return map[string]types.EnumFormatter{
+		"ParseMode": parseModes.Enum,
+	}
 }
 
 // GetURL returns a URL representation of it's current field values

--- a/pkg/services/telegram/telegram_config.go
+++ b/pkg/services/telegram/telegram_config.go
@@ -6,14 +6,15 @@ import (
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/types"
 	"net/url"
+	"strings"
 )
 
 // Config for use within the telegram plugin
 type Config struct {
 	Token        string
-	Preview      bool      `key:"preview" default:"yes" desc:"If disabled, no web page preview will be displayed for URLs"`
-	Notification bool      `key:"notification" default:"yes" desc:"If disabled, sends message silently"`
-	ParseMode    parseMode `key:"parsemode" default:"None"`
+	Preview      bool      `key:"preview" default:"Yes" desc:"If disabled, no web page preview will be displayed for URLs"`
+	Notification bool      `key:"notification" default:"Yes" desc:"If disabled, sends message silently"`
+	ParseMode    parseMode `key:"parsemode" default:"None" desc:"How the text message should be parsed"`
 	Channels     []string  `key:"channels"`
 }
 
@@ -38,8 +39,10 @@ func (config *Config) SetURL(url *url.URL) error {
 
 func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
 
+	tokenParts := strings.Split(config.Token, ":")
+
 	return &url.URL{
-		User:       url.UserPassword("Token", config.Token),
+		User:       url.UserPassword(tokenParts[0], tokenParts[1]),
 		Host:       Scheme,
 		Scheme:     Scheme,
 		ForceQuery: true,

--- a/pkg/services/telegram/telegram_internal_test.go
+++ b/pkg/services/telegram/telegram_internal_test.go
@@ -1,0 +1,85 @@
+package telegram
+
+import (
+	"encoding/json"
+	"errors"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"log"
+	"net/url"
+	"testing"
+)
+
+func TestTelegramInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoutrrr Telegram Suite")
+}
+
+var _ = Describe("the telegram service", func() {
+	var logger *log.Logger
+
+	BeforeEach(func() {
+		logger = log.New(GinkgoWriter, "Test", log.LstdFlags)
+	})
+
+	Describe("creating configurations", func() {
+		When("given an url", func() {
+
+			When("a parse mode is not supplied", func() {
+				It("no parse_mode should be present in payload", func() {
+					payload, err := getPayloadStringFromURL("telegram://12345:mock-token@telegram/?channels=channel-1", "Message", logger)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(payload).NotTo(ContainSubstring("parse_mode"))
+				})
+			})
+
+			When("a parse mode is supplied", func() {
+				When("it's set to a valid mode and not None", func() {
+					It("parse_mode should be present in payload", func() {
+						payload, err := getPayloadStringFromURL("telegram://12345:mock-token@telegram/?channels=channel-1&parsemode=Markdown", "Message", logger)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(payload).To(ContainSubstring("parse_mode"))
+					})
+				})
+				When("it's set to None", func() {
+					It("no parse_mode should be present in payload", func() {
+						payload, err := getPayloadStringFromURL("telegram://12345:mock-token@telegram/?channels=channel-1&parsemode=None", "Message", logger)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(payload).NotTo(ContainSubstring("parse_mode"))
+					})
+				})
+			})
+
+		})
+	})
+})
+
+func getPayloadFromURL(testURL string, message string, logger *log.Logger) (SendMessagePayload, error) {
+	telegram := &Service{}
+
+	serviceURL, err := url.Parse(testURL)
+	if err != nil {
+		return SendMessagePayload{}, err
+	}
+
+	if err = telegram.Initialize(serviceURL, logger); err != nil {
+		return SendMessagePayload{}, err
+	}
+
+	if len(telegram.config.Channels) < 1 {
+		return SendMessagePayload{}, errors.New("no channels were supplied")
+	}
+
+	return createSendMessagePayload(message, telegram.config.Channels[0], telegram.config), nil
+
+}
+
+func getPayloadStringFromURL(testURL string, message string, logger *log.Logger) ([]byte, error) {
+	payload, err := getPayloadFromURL(testURL, message, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := json.Marshal(payload)
+	return raw, err
+}

--- a/pkg/services/telegram/telegram_json.go
+++ b/pkg/services/telegram/telegram_json.go
@@ -1,7 +1,25 @@
 package telegram
 
 // JSON to be used as a notification payload for the telegram notification service
-type JSON struct {
-	Text string `json:"text"`
-	ID   string `json:"chat_id"`
+type SendMessagePayload struct {
+	Text                string `json:"text"`
+	ID                  string `json:"chat_id"`
+	ParseMode           string `json:"parse_mode,omitempty"`
+	DisablePreview      bool   `json:"disable_web_page_preview"`
+	DisableNotification bool   `json:"disable_notification"`
+}
+
+func createSendMessagePayload(message string, channel string, config *Config) SendMessagePayload {
+	payload := SendMessagePayload{
+		Text:                message,
+		ID:                  channel,
+		DisableNotification: !config.Notification,
+		DisablePreview:      !config.Preview,
+	}
+
+	if config.ParseMode != parseModes.None {
+		payload.ParseMode = config.ParseMode.String()
+	}
+
+	return payload
 }

--- a/pkg/services/telegram/telegram_parsemode.go
+++ b/pkg/services/telegram/telegram_parsemode.go
@@ -1,0 +1,34 @@
+package telegram
+
+import (
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
+)
+
+type parseMode int
+
+type parseModeVals struct {
+	None       parseMode
+	Markdown   parseMode
+	HTML       parseMode
+	MarkdownV2 parseMode
+	Enum       types.EnumFormatter
+}
+
+var parseModes = &parseModeVals{
+	None:       0,
+	Markdown:   1,
+	HTML:       2,
+	MarkdownV2: 3,
+	Enum: format.CreateEnumFormatter(
+		[]string{
+			"None",
+			"Markdown",
+			"HTML",
+			"MarkdownV2",
+		}),
+}
+
+func (pm parseMode) String() string {
+	return parseModes.Enum.Print(int(pm))
+}

--- a/pkg/services/telegram/telegram_test.go
+++ b/pkg/services/telegram/telegram_test.go
@@ -133,7 +133,7 @@ var _ = Describe("the telegram plugin", func() {
 		AfterEach(func() {
 			httpmock.DeactivateAndReset()
 		})
-		It("", func() {
+		It("should not report an error if the server accepts the payload", func() {
 			serviceURL, _ := url.Parse("telegram://12345:mock-token@telegram/?channels=channel-1,channel-2,channel-3")
 			err = telegram.Initialize(serviceURL, logger)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Adds three relevant options for the telegram service to be configured using either query variables or params.


Fixes #98: Add `&preview=no` to the query string to disable previews