### PR TITLE
use reflect.Indirect on Config for PropKeyResolver.set

### DIFF
--- a/pkg/format/prop_key_resolver.go
+++ b/pkg/format/prop_key_resolver.go
@@ -80,7 +80,7 @@ func (c *PropKeyResolver) set(target reflect.Value, key string, value string) er
 func (pkr *PropKeyResolver) UpdateConfigFromParams(config types.ServiceConfig, params *types.Params) error {
 	if params != nil {
 		for key, val := range *params {
-			if err := pkr.set(reflect.ValueOf(config), key, val); err != nil {
+			if err := pkr.set(reflect.Indirect(reflect.ValueOf(config)), key, val); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
hey
it seems like for the 4 services that use `UpdateConfigFromParams`, the provided config is a pointer 

so with this exampe

```go
package main

import (
	"github.com/containrrr/shoutrrr"
	"github.com/containrrr/shoutrrr/pkg/types"
)

func main() {
	sen, _ := shoutrrr.CreateSender("smtp://a:b@com:587?fromAddress=_&toAddresses=_")
	_ = sen.Send("Hello", &types.Params{
		"subject": "Hello",
	})
}
```

was hitting this panic:
```
panic: reflect: call of reflect.Value.FieldByName on ptr Value                                                                                                                
                                                                                                                                                                              
goroutine 20 [running]:                                                                                                                                                       
reflect.flag.mustBe(...)                                                                                                                                                      
        /usr/lib/go/src/reflect/value.go:221                                                                                                                                  
reflect.Value.FieldByName(0x7fa620, 0xc0000a8000, 0x16, 0x7dd602, 0x7, 0x83b9ad, 0x7, 0x401)                                                                                  
        /usr/lib/go/src/reflect/value.go:903 +0x1fa                                                                                                                           
github.com/containrrr/shoutrrr/pkg/format.SetConfigField(0x7fa620, 0xc0000a8000, 0x16, 0x7dd602, 0x7, 0x8beb20, 0x7ba160, 0x0, 0x0, 0x7dd611, ...)                            
        /home/senan/projects/shoutrrr/pkg/format/formatter.go:284 +0x74                                                                                                       
github.com/containrrr/shoutrrr/pkg/format.(*PropKeyResolver).set(0xc00017c110, 0x7fa620, 0xc0000a8000, 0x16, 0x83b9ad, 0x7, 0x83b49a, 0x6, 0x10, 0x7f89498677d0)              
        /home/senan/projects/shoutrrr/pkg/format/prop_key_resolver.go:69 +0x1b8                                                                                               
github.com/containrrr/shoutrrr/pkg/format.(*PropKeyResolver).UpdateConfigFromParams(0xc00017c110, 0x8b8dc0, 0xc0000a8000, 0xc000126028, 0x1, 0x1)                             
        /home/senan/projects/shoutrrr/pkg/format/prop_key_resolver.go:83 +0x187                                                                                               
github.com/containrrr/shoutrrr/pkg/services/smtp.(*Service).Send(0xc00017c0e0, 0x83ddd5, 0xe, 0xc000126028, 0x0, 0x0)                                                         
        /home/senan/projects/shoutrrr/pkg/services/smtp/smtp.go:73 +0x206                                                                                                     
github.com/containrrr/shoutrrr/pkg/router.sendToService.func1(0xc000128480, 0x8bb000, 0xc00017c0e0, 0x83ddd5, 0xe, 0xc000126028)                                              
        /home/senan/projects/shoutrrr/pkg/router/router.go:84 +0x4f                                                                                                           
created by github.com/containrrr/shoutrrr/pkg/router.sendToService                                                                                                            
        /home/senan/projects/shoutrrr/pkg/router/router.go:84 +0xda                                                                                                           
exit status 2                                                                      
```

so this PR indirects the value before passing to `PropKeyResolver.set`
not at all sure if this is a good idea, but at least I can point out that this error is a real thing

thanks :+1: 