### PR TITLE
feat: add standard title field

### DIFF
--- a/pkg/format/format_query.go
+++ b/pkg/format/format_query.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"fmt"
+
 	"github.com/containrrr/shoutrrr/pkg/types"
 )
 
@@ -10,7 +11,13 @@ func BuildQuery(cqr types.ConfigQueryResolver) string {
 	query := ""
 	format := "%s=%s"
 	fields := cqr.QueryFields()
+
+	pkr, isPkr := cqr.(*PropKeyResolver)
+
 	for index, key := range fields {
+		if isPkr && !pkr.KeyIsPrimary(key) {
+			continue
+		}
 		value, _ := cqr.Get(key)
 		if index == 1 {
 			format = "&%s=%s"

--- a/pkg/format/formatter.go
+++ b/pkg/format/formatter.go
@@ -3,11 +3,12 @@ package format
 import (
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
 	"reflect"
 	"strconv"
 	"strings"
 	"unsafe"
+
+	"github.com/fatih/color"
 
 	"github.com/containrrr/shoutrrr/pkg/types"
 	"github.com/containrrr/shoutrrr/pkg/util"
@@ -143,7 +144,7 @@ type FieldInfo struct {
 	Template      string
 	Required      bool
 	Title         bool
-	Key           string
+	Keys          []string
 }
 
 func (fmtr *formatter) getStructFieldInfo(structType reflect.Type) []FieldInfo {
@@ -189,7 +190,7 @@ func (fmtr *formatter) getStructFieldInfo(structType reflect.Type) []FieldInfo {
 		}
 
 		if tag, ok := fieldDef.Tag.Lookup("key"); ok {
-			info.Key = tag
+			info.Keys = strings.Split(tag, ",")
 		}
 
 		if ef, isEnum := fmtr.EnumFormatters[fieldDef.Name]; isEnum {

--- a/pkg/format/prop_key_resolver.go
+++ b/pkg/format/prop_key_resolver.go
@@ -3,13 +3,14 @@ package format
 import (
 	"errors"
 	"fmt"
-	"github.com/containrrr/shoutrrr/pkg/types"
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/containrrr/shoutrrr/pkg/types"
 )
 
-// KeyPropConfig implements the ServiceConfig interface for services that uses key tags for query props
+// PropKeyResolver implements the ConfigQueryResolver interface for services that uses key tags for query props
 type PropKeyResolver struct {
 	confValue reflect.Value
 	keyFields map[string]FieldInfo
@@ -23,10 +24,12 @@ func NewPropKeyResolver(config types.ServiceConfig) PropKeyResolver {
 	keyFields := make(map[string]FieldInfo, len(fields))
 	keys := make([]string, 0, len(fields))
 	for _, field := range fields {
-		key := strings.ToLower(field.Key)
-		if key != "" {
-			keys = append(keys, key)
-			keyFields[key] = field
+		for _, key := range field.Keys {
+			key = strings.ToLower(key)
+			if key != "" {
+				keys = append(keys, key)
+				keyFields[key] = field
+			}
 		}
 	}
 
@@ -102,4 +105,8 @@ func GetConfigQueryResolver(config types.ServiceConfig) types.ConfigQueryResolve
 		resolver = &pkr
 	}
 	return resolver
+}
+
+func (pkr *PropKeyResolver) KeyIsPrimary(key string) bool {
+	return pkr.keyFields[key].Keys[0] == key
 }

--- a/pkg/services/smtp/smtp_config.go
+++ b/pkg/services/smtp/smtp_config.go
@@ -3,10 +3,11 @@ package smtp
 import (
 	"errors"
 	"fmt"
-	"github.com/containrrr/shoutrrr/pkg/format"
-	"github.com/containrrr/shoutrrr/pkg/types"
 	"net/url"
 	"strconv"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
 )
 
 // Config is the configuration needed to send e-mail notifications over SMTP
@@ -18,7 +19,7 @@ type Config struct {
 	FromAddress string    `desc:"e-mail address that the mail are sent from" key:"fromaddress"`
 	FromName    string    `desc:"name of the sender" optional:"yes" key:"fromname"`
 	ToAddresses []string  `desc:"list of recipient e-mails separated by \",\" (comma)" key:"toaddresses"`
-	Subject     string    `desc:"the subject of the sent mail" key:"subject" default:"Shoutrrr Notification" field:"title"`
+	Subject     string    `desc:"the subject of the sent mail" key:"subject,title" default:"Shoutrrr Notification"`
 	Auth        authType  `desc:"SMTP authentication method" key:"auth"`
 	Encryption  encMethod `desc:"Encryption method" default:"Auto" key:"encryption"`
 	UseStartTLS bool      `desc:"attempt to use SMTP StartTLS encryption" default:"Yes" key:"starttls"`

--- a/pkg/services/smtp/smtp_test.go
+++ b/pkg/services/smtp/smtp_test.go
@@ -98,7 +98,7 @@ var _ = Describe("the SMTP service", func() {
 
 		It("should have the exped number of fields and enums", func() {
 			testutils.TestConfigGetEnumsCount(config, 2)
-			testutils.TestConfigGetFieldsCount(config, 8)
+			testutils.TestConfigGetFieldsCount(config, 9)
 		})
 	})
 


### PR DESCRIPTION
This will add support for multiple key names in the `key` tag (separated by commas), which allows all services to use the `title` key as an alias (or as the primary key).
This also adds said alias to the SMTP service for the `subject` field and a `title` argument to the `send` command.

Fixes #30 