### PR TITLE
fix(gotify): use pkr for fields to make them settable from url

### DIFF
--- a/pkg/services/gotify/gotify.go
+++ b/pkg/services/gotify/gotify.go
@@ -59,7 +59,11 @@ func buildURL(config *Config) (string, error) {
 	if !isTokenValid(token) {
 		return "", fmt.Errorf("invalid gotify token \"%s\"", token)
 	}
-	return fmt.Sprintf("https://%s/message?token=%s", config.Host, token), nil
+	scheme := "https"
+	if config.DisableTLS {
+		scheme = scheme[:4]
+	}
+	return fmt.Sprintf("%s://%s/message?token=%s", scheme, config.Host, token), nil
 }
 
 // Send a notification message to Gotify

--- a/pkg/services/gotify/gotify.go
+++ b/pkg/services/gotify/gotify.go
@@ -23,7 +23,9 @@ type Service struct {
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
 func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
 	service.Logger.SetLogger(logger)
-	service.config = &Config{}
+	service.config = &Config{
+		Title: "Shoutrrr notification",
+	}
 	err := service.config.SetURL(configURL)
 	return err
 }
@@ -70,10 +72,10 @@ func getPriority(params map[string]string) int {
 	return priority
 }
 
-func getTitle(params map[string]string) string {
+func getTitle(params map[string]string, config *Config) string {
 	title, ok := params["title"]
 	if !ok {
-		title = "Shoutrrr notification"
+		title = config.Title
 	}
 	return title
 }
@@ -90,7 +92,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 	}
 	jsonBody, err := json.Marshal(JSON{
 		Message:  message,
-		Title:    getTitle(*params),
+		Title:    getTitle(*params, config),
 		Priority: getPriority(*params),
 	})
 	if err != nil {

--- a/pkg/services/gotify/gotify_config.go
+++ b/pkg/services/gotify/gotify_config.go
@@ -12,6 +12,7 @@ type Config struct {
 	Token   string
 	Host    string
 	Prority int
+	Title   string `default:"Shoutrrr notification"`
 }
 
 // GetURL returns a URL representation of it's current field values

--- a/pkg/services/gotify/gotify_config.go
+++ b/pkg/services/gotify/gotify_config.go
@@ -11,10 +11,11 @@ import (
 // Config for use within the gotify plugin
 type Config struct {
 	standard.EnumlessConfig
-	Token    string
-	Host     string
-	Priority int    `key:"priority" default:"0"`
-	Title    string `key:"title" default:"Shoutrrr notification"`
+	Token      string
+	Host       string
+	Priority   int    `key:"priority" default:"0"`
+	Title      string `key:"title" default:"Shoutrrr notification"`
+	DisableTLS bool   `key:"disabletls" default:"No"`
 }
 
 // GetURL returns a URL representation of it's current field values
@@ -29,7 +30,6 @@ func (config *Config) SetURL(url *url.URL) error {
 	return config.setURL(&resolver, url)
 }
 
-// GetURL returns a URL representation of it's current field values
 func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
 	return &url.URL{
 		Host:       config.Host,
@@ -40,7 +40,6 @@ func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
 	}
 }
 
-// SetURL updates a ServiceConfig from a URL representation of it's field values
 func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) error {
 	config.Host = url.Host
 	config.Token = url.Path

--- a/pkg/services/gotify/gotify_config.go
+++ b/pkg/services/gotify/gotify_config.go
@@ -1,6 +1,8 @@
 package gotify
 
 import (
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
 	"net/url"
 
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
@@ -9,26 +11,45 @@ import (
 // Config for use within the gotify plugin
 type Config struct {
 	standard.EnumlessConfig
-	Token   string
-	Host    string
-	Prority int
-	Title   string `default:"Shoutrrr notification"`
+	Token    string
+	Host     string
+	Priority int    `key:"priority" default:"0"`
+	Title    string `key:"title" default:"Shoutrrr notification"`
 }
 
 // GetURL returns a URL representation of it's current field values
 func (config *Config) GetURL() *url.URL {
+	resolver := format.NewPropKeyResolver(config)
+	return config.getURL(&resolver)
+}
+
+// SetURL updates a ServiceConfig from a URL representation of it's field values
+func (config *Config) SetURL(url *url.URL) error {
+	resolver := format.NewPropKeyResolver(config)
+	return config.setURL(&resolver, url)
+}
+
+// GetURL returns a URL representation of it's current field values
+func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
 	return &url.URL{
 		Host:       config.Host,
 		Scheme:     Scheme,
 		ForceQuery: false,
 		Path:       config.Token,
+		RawQuery:   format.BuildQuery(resolver),
 	}
 }
 
 // SetURL updates a ServiceConfig from a URL representation of it's field values
-func (config *Config) SetURL(url *url.URL) error {
-	config.Host = url.Hostname()
+func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) error {
+	config.Host = url.Host
 	config.Token = url.Path
+
+	for key, vals := range url.Query() {
+		if err := resolver.Set(key, vals[0]); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/services/gotify/gotify_test.go
+++ b/pkg/services/gotify/gotify_test.go
@@ -1,6 +1,10 @@
 package gotify
 
 import (
+	"errors"
+	"github.com/jarcoal/httpmock"
+	"log"
+	"net/url"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -12,6 +16,8 @@ func TestGotify(t *testing.T) {
 	RunSpecs(t, "Shoutrrr Gotify Suite")
 }
 
+var logger *log.Logger
+
 var _ = Describe("the Gotify plugin URL building and token validation functions", func() {
 	It("should build a valid gotify URL", func() {
 		config := Config{
@@ -22,29 +28,6 @@ var _ = Describe("the Gotify plugin URL building and token validation functions"
 		Expect(err).To(BeNil())
 		expectedURL := "https://my.gotify.tld/message?token=Aaa.bbb.ccc.ddd"
 		Expect(url).To(Equal(expectedURL))
-	})
-	When("provided empty params", func() {
-		It("should return 0", func() {
-			params := make(map[string]string)
-			priority := getPriority(params)
-			Expect(priority).To(Equal(0))
-		})
-	})
-	When("provided invalid params", func() {
-		It("should return 0", func() {
-			params := make(map[string]string)
-			params["priority"] = "not an integer"
-			priority := getPriority(params)
-			Expect(priority).To(Equal(0))
-		})
-	})
-	When("provided 42", func() {
-		It("should return 42", func() {
-			params := make(map[string]string)
-			params["priority"] = "42"
-			priority := getPriority(params)
-			Expect(priority).To(Equal(42))
-		})
 	})
 	When("provided a valid token", func() {
 		It("should return true", func() {
@@ -62,6 +45,58 @@ var _ = Describe("the Gotify plugin URL building and token validation functions"
 		It("should return false", func() {
 			token := "Chwbsdyhwwga"
 			Expect(isTokenValid(token)).To(BeFalse())
+		})
+	})
+	Describe("creating a config", func() {
+		When("parsing the configuration URL", func() {
+			It("should be identical after de-/serialization", func() {
+				testURL := "gotify://my.gotify.tld/Aaa.bbb.ccc.ddd?priority=1&title=Test title"
+
+				url, err := url.Parse(testURL)
+				Expect(err).NotTo(HaveOccurred(), "parsing")
+
+				config := &Config{}
+				err = config.SetURL(url)
+				Expect(err).NotTo(HaveOccurred(), "verifying")
+
+				outputURL := config.GetURL()
+
+				Expect(outputURL.String()).To(Equal(testURL))
+
+			})
+		})
+	})
+
+	Describe("sending the payload", func() {
+		var err error
+		var service Service
+		BeforeEach(func() {
+			httpmock.Activate()
+		})
+		AfterEach(func() {
+			httpmock.DeactivateAndReset()
+		})
+		It("should not report an error if the server accepts the payload", func() {
+			serviceURL, _ := url.Parse("gotify://my.gotify.tld/Aaa.bbb.ccc.ddd")
+			err = service.Initialize(serviceURL, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			targetURL := "https://my.gotify.tld/message?token=Aaa.bbb.ccc.ddd"
+			httpmock.RegisterResponder("POST", targetURL, httpmock.NewStringResponder(200, ""))
+
+			err = service.Send("Message", nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should not panic if an error occurs when sending the payload", func() {
+			serviceURL, _ := url.Parse("gotify://my.gotify.tld/Aaa.bbb.ccc.ddd")
+			err = service.Initialize(serviceURL, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			targetURL := "https://my.gotify.tld/message?token=Aaa.bbb.ccc.ddd"
+			httpmock.RegisterResponder("POST", targetURL, httpmock.NewErrorResponder(errors.New("dummy error")))
+
+			err = service.Send("Message", nil)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/pkg/services/gotify/gotify_test.go
+++ b/pkg/services/gotify/gotify_test.go
@@ -29,6 +29,21 @@ var _ = Describe("the Gotify plugin URL building and token validation functions"
 		expectedURL := "https://my.gotify.tld/message?token=Aaa.bbb.ccc.ddd"
 		Expect(url).To(Equal(expectedURL))
 	})
+
+	When("TLS is disabled", func() {
+		It("should use http schema", func() {
+			config := Config{
+				Token:      "Aaa.bbb.ccc.ddd",
+				Host:       "my.gotify.tld",
+				DisableTLS: true,
+			}
+			url, err := buildURL(&config)
+			Expect(err).To(BeNil())
+			expectedURL := "http://my.gotify.tld/message?token=Aaa.bbb.ccc.ddd"
+			Expect(url).To(Equal(expectedURL))
+		})
+	})
+
 	When("provided a valid token", func() {
 		It("should return true", func() {
 			token := "Ahwbsdyhwwgarxd"
@@ -50,7 +65,7 @@ var _ = Describe("the Gotify plugin URL building and token validation functions"
 	Describe("creating a config", func() {
 		When("parsing the configuration URL", func() {
 			It("should be identical after de-/serialization", func() {
-				testURL := "gotify://my.gotify.tld/Aaa.bbb.ccc.ddd?priority=1&title=Test title"
+				testURL := "gotify://my.gotify.tld/Aaa.bbb.ccc.ddd?disabletls=No&priority=1&title=Test title"
 
 				url, err := url.Parse(testURL)
 				Expect(err).NotTo(HaveOccurred(), "parsing")
@@ -98,5 +113,6 @@ var _ = Describe("the Gotify plugin URL building and token validation functions"
 			err = service.Send("Message", nil)
 			Expect(err).To(HaveOccurred())
 		})
+
 	})
 })


### PR DESCRIPTION
This adds the `title` and `priority` fields to the config and URL (previously only settable with params).
It also adds support for disabling TLS for non-https servers.

Ref: https://github.com/containrrr/watchtower/issues/761