### PR TITLE
fix(teams): use better URL format and nicer output

### DIFF
--- a/pkg/router/router_suite_test.go
+++ b/pkg/router/router_suite_test.go
@@ -75,6 +75,19 @@ var _ = Describe("the router suite", func() {
 		})
 	})
 
+	When("initializing a service with a custom URL", func() {
+		It("should return an error if the service does not support it", func() {
+			service, err := sr.initService("log+https://hybr.is")
+			Expect(err).To(HaveOccurred())
+			Expect(service).To(BeNil())
+		})
+		It("should successfully init a service that does support it", func() {
+			service, err := sr.initService("teams+https://hybr.is")
+			Expect(err).To(HaveOccurred())
+			Expect(service).To(BeNil())
+		})
+	})
+
 	When("a message is enqueued", func() {
 		It("should be added to the internal queue", func() {
 

--- a/pkg/router/router_suite_test.go
+++ b/pkg/router/router_suite_test.go
@@ -19,7 +19,9 @@ var sr ServiceRouter
 
 var _ = Describe("the router suite", func() {
 	BeforeEach(func() {
-		sr = ServiceRouter{}
+		sr = ServiceRouter{
+			logger: log.New(GinkgoWriter, "Test", log.LstdFlags),
+		}
 	})
 
 	When("extract service name is given a url", func() {
@@ -82,9 +84,9 @@ var _ = Describe("the router suite", func() {
 			Expect(service).To(BeNil())
 		})
 		It("should successfully init a service that does support it", func() {
-			service, err := sr.initService("teams+https://hybr.is")
-			Expect(err).To(HaveOccurred())
-			Expect(service).To(BeNil())
+			service, err := sr.initService("teams+https://publicservice.info/webhook/11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/IncomingWebhook/33333333012222222222333333333344/44444444-4444-4444-8444-cccccccccccc")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(service).NotTo(BeNil())
 		})
 	})
 

--- a/pkg/services/teams/teams.go
+++ b/pkg/services/teams/teams.go
@@ -47,10 +47,10 @@ func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error
 }
 
 func (service *Service) doSend(config *Config, message string) error {
-	var sections []Section
+	var sections []section
 
 	for _, line := range strings.Split(message, "\n") {
-		sections = append(sections, Section{
+		sections = append(sections, section{
 			Text: line,
 		})
 	}
@@ -64,7 +64,7 @@ func (service *Service) doSend(config *Config, message string) error {
 		}
 	}
 
-	payload, err := json.Marshal(Payload{
+	payload, err := json.Marshal(payload{
 		CardType:   "MessageCard",
 		Context:    "http://schema.org/extensions",
 		Markdown:   true,

--- a/pkg/services/teams/teams.go
+++ b/pkg/services/teams/teams.go
@@ -39,11 +39,7 @@ func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error
 
 	service.pkr = format.NewPropKeyResolver(service.config)
 
-	if err := service.config.setURL(&service.pkr, configURL); err != nil {
-		return err
-	}
-
-	return nil
+	return service.config.setURL(&service.pkr, configURL)
 }
 
 func (service *Service) doSend(config *Config, message string) error {

--- a/pkg/services/teams/teams.go
+++ b/pkg/services/teams/teams.go
@@ -45,7 +45,7 @@ func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error
 }
 
 // GetConfigURLFromCustom creates a regular service URL from one with a custom host
-func (_ *Service) GetConfigURLFromCustom(customURL *url.URL) (serviceURL *url.URL, err error) {
+func (*Service) GetConfigURLFromCustom(customURL *url.URL) (serviceURL *url.URL, err error) {
 	parts, err := parseAndVerifyWebhookURL(customURL.String())
 	if err != nil {
 		return nil, err

--- a/pkg/services/teams/teams_config.go
+++ b/pkg/services/teams/teams_config.go
@@ -1,7 +1,12 @@
 package teams
 
 import (
+	"fmt"
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
 	"net/url"
+	"regexp"
+	"strings"
 
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 )
@@ -9,32 +14,112 @@ import (
 // Config for use within the teams plugin
 type Config struct {
 	standard.EnumlessConfig
-	Token Token
+	WebhookParts [4]string
+	Title        string `key:"title" optional:""`
+	Color        string `key:"color" optional:""`
+}
+
+// CreateConfigFromWebhookURL creates a new config from a teams webhook URL
+func CreateConfigFromWebhookURL(webhookURL string) (*Config, error) {
+	parts, err := parseWebhookURL(webhookURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Config{WebhookParts: parts}, nil
 }
 
 // GetURL returns a URL representation of it's current field values
 func (config *Config) GetURL() *url.URL {
-	return &url.URL{
-		User:       url.UserPassword(config.Token.A, config.Token.B),
-		Host:       config.Token.C,
-		Scheme:     Scheme,
-		ForceQuery: false,
-	}
+	resolver := format.NewPropKeyResolver(config)
+	return config.getURL(&resolver)
 }
 
 // SetURL updates a ServiceConfig from a URL representation of it's field values
 func (config *Config) SetURL(url *url.URL) error {
+	resolver := format.NewPropKeyResolver(config)
+	return config.setURL(&resolver, url)
+}
 
-	tokenA := url.User.Username()
-	tokenB, _ := url.User.Password()
-	tokenC := url.Hostname()
+func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
+	parts := config.WebhookParts
 
-	config.Token = Token{
-		A: tokenA,
-		B: tokenB,
-		C: tokenC,
+	return &url.URL{
+		User:       url.User(parts[0]),
+		Host:       parts[1],
+		Path:       "/" + parts[2] + parts[3] + "/",
+		Scheme:     Scheme,
+		ForceQuery: false,
+		RawQuery:   format.BuildQuery(resolver),
 	}
+}
+
+func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) error {
+	var webhookParts [4]string
+
+	if pass, legacyFormat := url.User.Password(); legacyFormat {
+		parts := strings.Split(url.User.Username(), "@")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid URL format")
+		}
+		webhookParts = [4]string{parts[0], parts[1], pass, url.Hostname()}
+	} else {
+		parts := strings.Split(url.Path, "/")
+		if parts[0] == "" {
+			parts = parts[1:]
+		}
+		webhookParts = [4]string{url.User.Username(), url.Hostname(), parts[0], parts[1]}
+	}
+
+	if err := VerifyWebhookParts(webhookParts); err != nil {
+		return fmt.Errorf("invalid URL format: %v", err)
+	}
+
+	config.WebhookParts = webhookParts
+
+	for key, vals := range url.Query() {
+		if err := resolver.Set(key, vals[0]); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+func buildWebhookURL(parts [4]string) string {
+	return fmt.Sprintf(
+		"https://outlook.office.com/webhook/%s@%s/IncomingWebhook/%s/%s",
+		parts[0],
+		parts[1],
+		parts[2],
+		parts[3])
+}
+
+func parseWebhookURL(webhookURL string) (parts [4]string, err error) {
+	if len(webhookURL) < 195 {
+		return parts, fmt.Errorf("invalid webhook URL format")
+	}
+	return [4]string{
+		webhookURL[35:71],
+		webhookURL[72:108],
+		webhookURL[125:157],
+		webhookURL[158:194],
+	}, nil
+}
+
+func parseAndVerifyWebhookURL(webhookURL string) (parts [4]string, err error) {
+	pattern, err := regexp.Compile(`([0-9a-f-]{36})@([0-9a-f-]{36})/[^/]+/([0-9a-f]{32})/([0-9a-f-]{36})`)
+	if err != nil {
+		return parts, err
+	}
+
+	groups := pattern.FindStringSubmatch(webhookURL)
+	if len(groups) != 5 {
+		return parts, fmt.Errorf("invalid webhook URL format")
+	}
+
+	copy(parts[:], groups[1:])
+	return parts, nil
 }
 
 // CreateConfigFromURL for use within the teams plugin

--- a/pkg/services/teams/teams_config.go
+++ b/pkg/services/teams/teams_config.go
@@ -133,6 +133,7 @@ func (service *Service) CreateConfigFromURL(url *url.URL) (*Config, error) {
 
 const (
 	// Scheme is the identifying part of this service's configuration URL
-	Scheme      = "teams"
+	Scheme = "teams"
+	// DefaultHost is the default host for the webhook request
 	DefaultHost = "outlook.office.com"
 )

--- a/pkg/services/teams/teams_config.go
+++ b/pkg/services/teams/teams_config.go
@@ -17,6 +17,7 @@ type Config struct {
 	WebhookParts [4]string
 	Title        string `key:"title" optional:""`
 	Color        string `key:"color" optional:""`
+	Host         string `key:"host" optional:"" default:"outlook.office.com"`
 }
 
 // SetFromWebhookURL updates the config WebhookParts from a teams webhook URL
@@ -86,9 +87,10 @@ func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) e
 	return nil
 }
 
-func buildWebhookURL(parts [4]string) string {
+func buildWebhookURL(host string, parts [4]string) string {
 	return fmt.Sprintf(
-		"https://outlook.office.com/webhook/%s@%s/IncomingWebhook/%s/%s",
+		"https://%s/webhook/%s@%s/IncomingWebhook/%s/%s",
+		host,
 		parts[0],
 		parts[1],
 		parts[2],
@@ -131,5 +133,6 @@ func (service *Service) CreateConfigFromURL(url *url.URL) (*Config, error) {
 
 const (
 	// Scheme is the identifying part of this service's configuration URL
-	Scheme = "teams"
+	Scheme      = "teams"
+	DefaultHost = "outlook.office.com"
 )

--- a/pkg/services/teams/teams_config.go
+++ b/pkg/services/teams/teams_config.go
@@ -19,8 +19,8 @@ type Config struct {
 	Color        string `key:"color" optional:""`
 }
 
-// CreateConfigFromWebhookURL creates a new config from a teams webhook URL
-func CreateConfigFromWebhookURL(webhookURL string) (*Config, error) {
+// SetFromWebhookURL updates the config WebhookParts from a teams webhook URL
+func (config *Config) SetFromWebhookURL(webhookURL string) (*Config, error) {
 	parts, err := parseWebhookURL(webhookURL)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
 	return &url.URL{
 		User:       url.User(parts[0]),
 		Host:       parts[1],
-		Path:       "/" + parts[2] + parts[3] + "/",
+		Path:       "/" + parts[2] + "/" + parts[3],
 		Scheme:     Scheme,
 		ForceQuery: false,
 		RawQuery:   format.BuildQuery(resolver),
@@ -71,7 +71,7 @@ func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) e
 		webhookParts = [4]string{url.User.Username(), url.Hostname(), parts[0], parts[1]}
 	}
 
-	if err := VerifyWebhookParts(webhookParts); err != nil {
+	if err := verifyWebhookParts(webhookParts); err != nil {
 		return fmt.Errorf("invalid URL format: %v", err)
 	}
 

--- a/pkg/services/teams/teams_json.go
+++ b/pkg/services/teams/teams_json.go
@@ -1,9 +1,25 @@
 package teams
 
 // JSON is the actual payload being sent to the teams api
-type JSON struct {
-	CardType string `json:"@type"`
-	Context  string `json:"@context"`
-	Markdown bool   `json:"markdown,bool"`
-	Text     string `json:"text,omitempty"`
+type Payload struct {
+	CardType   string    `json:"@type"`
+	Context    string    `json:"@context"`
+	Markdown   bool      `json:"markdown,bool"`
+	Text       string    `json:"text,omitempty"`
+	Title      string    `json:"title,omitempty"`
+	Summary    string    `json:"summary,omitempty"`
+	Sections   []Section `json:"sections,omitempty"`
+	ThemeColor string    `json:"themeColor,omitempty"`
+}
+
+type Section struct {
+	Text         string `json:"text,omitempty"`
+	ActivityText string `json:"activityText,omitempty"`
+	StartGroup   bool   `json:"startGroup"`
+	Facts        []Fact `json:"facts,omitempty"`
+}
+
+type Fact struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }

--- a/pkg/services/teams/teams_json.go
+++ b/pkg/services/teams/teams_json.go
@@ -1,25 +1,25 @@
 package teams
 
 // JSON is the actual payload being sent to the teams api
-type Payload struct {
+type payload struct {
 	CardType   string    `json:"@type"`
 	Context    string    `json:"@context"`
 	Markdown   bool      `json:"markdown,bool"`
 	Text       string    `json:"text,omitempty"`
 	Title      string    `json:"title,omitempty"`
 	Summary    string    `json:"summary,omitempty"`
-	Sections   []Section `json:"sections,omitempty"`
+	Sections   []section `json:"sections,omitempty"`
 	ThemeColor string    `json:"themeColor,omitempty"`
 }
 
-type Section struct {
+type section struct {
 	Text         string `json:"text,omitempty"`
 	ActivityText string `json:"activityText,omitempty"`
 	StartGroup   bool   `json:"startGroup"`
-	Facts        []Fact `json:"facts,omitempty"`
+	Facts        []fact `json:"facts,omitempty"`
 }
 
-type Fact struct {
+type fact struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }

--- a/pkg/services/teams/teams_test.go
+++ b/pkg/services/teams/teams_test.go
@@ -1,11 +1,22 @@
 package teams
 
 import (
+	"errors"
+	"github.com/jarcoal/httpmock"
+	"log"
+	"net/url"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+const (
+	testWebhookURL = "https://outlook.office.com/webhook/11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/IncomingWebhook/33333333012222222222333333333344/44444444-4444-4444-8444-cccccccccccc"
+	testURLBase    = "teams://11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/33333333012222222222333333333344/44444444-4444-4444-8444-cccccccccccc"
+)
+
+var logger = log.New(GinkgoWriter, "Test", log.LstdFlags)
 
 func TestTeams(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -13,17 +24,74 @@ func TestTeams(t *testing.T) {
 }
 
 var _ = Describe("the teams plugin", func() {
-	It("should work", func() {
-		config := Config{
-			Token: Token{
-				"88888888-4444-333-333-cccccccccccc",
-				"11111111112222222222333333333344",
-				"88888888-4444-333-333-cccccccccccc",
-			},
-		}
-		// testutils.TestConfigSetInvalidQueryValue(&Config{}, "teams://88888888-4444-333-333-cccccccccccc:11111111112222222222333333333344@88888888-4444-333-333-cccccccccccc/?foo=bar")
-		apiURL := buildURL(&config)
-		expectedURL := "https://outlook.office.com/webhook/88888888-4444-333-333-cccccccccccc/IncomingWebhook/11111111112222222222333333333344/88888888-4444-333-333-cccccccccccc"
-		Expect(apiURL).To(Equal(expectedURL))
+	When("creating the webhook URL", func() {
+		It("should match the expected output", func() {
+			config := Config{
+				WebhookParts: [4]string{
+					"11111111-4444-4444-8444-cccccccccccc",
+					"22222222-4444-4444-8444-cccccccccccc",
+					"33333333012222222222333333333344",
+					"44444444-4444-4444-8444-cccccccccccc",
+				},
+			}
+			apiURL := buildWebhookURL(config.WebhookParts)
+			Expect(apiURL).To(Equal(testWebhookURL))
+
+			parts, err := parseAndVerifyWebhookURL(apiURL)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parts).To(Equal(config.WebhookParts))
+		})
 	})
+
+	Describe("creating a config", func() {
+		When("parsing the configuration URL", func() {
+			It("should be identical after de-/serialization", func() {
+				testURL := testURLBase + "?color=aabbcc&title=Test title"
+
+				url, err := url.Parse(testURL)
+				Expect(err).NotTo(HaveOccurred(), "parsing")
+
+				config := &Config{}
+				err = config.SetURL(url)
+				Expect(err).NotTo(HaveOccurred(), "verifying")
+
+				outputURL := config.GetURL()
+				Expect(outputURL.String()).To(Equal(testURL))
+
+			})
+		})
+	})
+
+	Describe("sending the payload", func() {
+		var err error
+		var service Service
+		BeforeEach(func() {
+			httpmock.Activate()
+		})
+		AfterEach(func() {
+			httpmock.DeactivateAndReset()
+		})
+		It("should not report an error if the server accepts the payload", func() {
+			serviceURL, _ := url.Parse(testURLBase)
+			err = service.Initialize(serviceURL, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			httpmock.RegisterResponder("POST", testWebhookURL, httpmock.NewStringResponder(200, ""))
+
+			err = service.Send("Message", nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should not panic if an error occurs when sending the payload", func() {
+			serviceURL, _ := url.Parse(testURLBase)
+			err = service.Initialize(serviceURL, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			httpmock.RegisterResponder("POST", testWebhookURL, httpmock.NewErrorResponder(errors.New("dummy error")))
+
+			err = service.Send("Message", nil)
+			Expect(err).To(HaveOccurred())
+		})
+
+	})
+
 })

--- a/pkg/services/teams/teams_token.go
+++ b/pkg/services/teams/teams_token.go
@@ -8,25 +8,25 @@ import (
 var uuid4Pattern = "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
 var hex32Pattern = "[A-Za-z0-9]{32}"
 
-func Part124Valid(token string) bool {
+func uuidPartValid(token string) bool {
 	return matchesRegexp(uuid4Pattern, token)
 }
 
-func Part3Valid(token string) bool {
+func hashPartValid(token string) bool {
 	return matchesRegexp(hex32Pattern, token)
 }
 
-func VerifyWebhookParts(p [4]string) error {
-	if !Part124Valid(p[0]) {
+func verifyWebhookParts(p [4]string) error {
+	if !uuidPartValid(p[0]) {
 		return fmt.Errorf("first token part is invalid: '%v'", p[0])
 	}
-	if !Part124Valid(p[1]) {
+	if !uuidPartValid(p[1]) {
 		return fmt.Errorf("second token part is invalid: '%v'", p[1])
 	}
-	if !Part3Valid(p[2]) {
+	if !hashPartValid(p[2]) {
 		return fmt.Errorf("third token part is invalid: '%v'", p[2])
 	}
-	if !Part124Valid(p[3]) {
+	if !uuidPartValid(p[3]) {
 		return fmt.Errorf("forth token part is invalid: '%v'", p[3])
 	}
 	return nil

--- a/pkg/services/teams/teams_token.go
+++ b/pkg/services/teams/teams_token.go
@@ -1,59 +1,38 @@
 package teams
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 )
 
 var uuid4Pattern = "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+var hex32Pattern = "[A-Za-z0-9]{32}"
 
-// Token to be used with the teams notification service
-type Token struct {
-	A string
-	B string
-	C string
-}
-
-func isTokenValid(arguments []string) bool {
-	return isTokenAValid(arguments[0]) &&
-		isTokenBValid(arguments[1]) &&
-		isTokenCValid(arguments[2])
-}
-
-func isTokenAValid(token string) bool {
-	pattern := fmt.Sprintf("%s@%s", uuid4Pattern, uuid4Pattern)
-	return matchesRegexp(pattern, token)
-}
-
-func isTokenBValid(token string) bool {
-	return matchesRegexp("[A-Za-z0-9]{32}", token)
-}
-
-func isTokenCValid(token string) bool {
+func Part124Valid(token string) bool {
 	return matchesRegexp(uuid4Pattern, token)
+}
+
+func Part3Valid(token string) bool {
+	return matchesRegexp(hex32Pattern, token)
+}
+
+func VerifyWebhookParts(p [4]string) error {
+	if !Part124Valid(p[0]) {
+		return fmt.Errorf("first token part is invalid: '%v'", p[0])
+	}
+	if !Part124Valid(p[1]) {
+		return fmt.Errorf("second token part is invalid: '%v'", p[1])
+	}
+	if !Part3Valid(p[2]) {
+		return fmt.Errorf("third token part is invalid: '%v'", p[2])
+	}
+	if !Part124Valid(p[3]) {
+		return fmt.Errorf("forth token part is invalid: '%v'", p[3])
+	}
+	return nil
 }
 
 func matchesRegexp(pattern string, token string) bool {
 	matched, err := regexp.MatchString(pattern, token)
-	return !matched || err != nil
-}
-
-func (t Token) String() string {
-	return fmt.Sprintf("%s-%s-%s", t.A, t.B, t.C)
-}
-
-// ParseToken creates a token from a string representation
-func ParseToken(s string) (Token, error) {
-	parts := strings.Split(s, "_")
-	if !isTokenValid(parts) {
-		return Token{}, errors.New("invalid service url. malformed tokens")
-	}
-
-	return Token{
-		A: parts[0],
-		B: parts[1],
-		C: parts[2],
-	}, nil
+	return matched && err == nil
 }


### PR DESCRIPTION
- Change the URL format (with support for reading the old format) to one that is easier to type by hand
- Add title and color fields
- Use `sections` for messages (align with common bot output)
- Correctly parse and test webhook URLs
- Add groundwork for rich API