### PR TITLE
fix(slack): use attachments and add title and color fields

### DIFF
--- a/pkg/services/slack/slack.go
+++ b/pkg/services/slack/slack.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"log"
@@ -22,8 +21,7 @@ type Service struct {
 }
 
 const (
-	apiURL    = "https://hooks.slack.com/services"
-	maxlength = 1000
+	apiURL = "https://hooks.slack.com/services"
 )
 
 // Send a notification message to Slack
@@ -36,9 +34,6 @@ func (service *Service) Send(message string, params *types.Params) error {
 
 	if err := ValidateToken(config.Token); err != nil {
 		return err
-	}
-	if len(message) > maxlength {
-		return errors.New("message exceeds max length")
 	}
 
 	return service.doSend(config, message)

--- a/pkg/services/slack/slack.go
+++ b/pkg/services/slack/slack.go
@@ -49,11 +49,7 @@ func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	service.pkr = format.NewPropKeyResolver(service.config)
-	if err := service.config.setURL(&service.pkr, configURL); err != nil {
-		return err
-	}
-
-	return nil
+	return service.config.setURL(&service.pkr, configURL)
 }
 
 func (service *Service) doSend(config *Config, message string) error {

--- a/pkg/services/slack/slack_config.go
+++ b/pkg/services/slack/slack_config.go
@@ -2,7 +2,9 @@ package slack
 
 import (
 	"fmt"
+	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
+	"github.com/containrrr/shoutrrr/pkg/types"
 	"net/url"
 	"strings"
 )
@@ -10,28 +12,38 @@ import (
 // Config for the slack service
 type Config struct {
 	standard.EnumlessConfig
-	BotName string   `default:"Shoutrrr"`
+	BotName string   `default:"" optional:""`
 	Token   []string `description:"List of comma separated token parts"`
+	Color   string   `key:"color" optional:""`
+	Title   string   `key:"title" optional:""`
 }
 
 // GetURL returns a URL representation of it's current field values
 func (config *Config) GetURL() *url.URL {
+	resolver := format.NewPropKeyResolver(config)
+	return config.getURL(&resolver)
+}
+
+// SetURL updates a ServiceConfig from a URL representation of it's field values
+func (config *Config) SetURL(url *url.URL) error {
+	resolver := format.NewPropKeyResolver(config)
+	return config.setURL(&resolver, url)
+}
+
+func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
 	return &url.URL{
 		User:       url.User(config.BotName),
 		Host:       config.Token[0],
 		Path:       fmt.Sprintf("/%s/%s", config.Token[1], config.Token[2]),
 		Scheme:     Scheme,
 		ForceQuery: false,
+		RawQuery:   format.BuildQuery(resolver),
 	}
 }
 
-// SetURL updates a ServiceConfig from a URL representation of it's field values
-func (config *Config) SetURL(serviceURL *url.URL) error {
+func (config *Config) setURL(resolver types.ConfigQueryResolver, serviceURL *url.URL) error {
 
 	botName := serviceURL.User.Username()
-	if botName == "" {
-		botName = DefaultUser
-	}
 
 	host := serviceURL.Hostname()
 
@@ -49,12 +61,16 @@ func (config *Config) SetURL(serviceURL *url.URL) error {
 		return err
 	}
 
+	for key, vals := range serviceURL.Query() {
+		if err := resolver.Set(key, vals[0]); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 const (
-	// DefaultUser for sending notifications to slack
-	DefaultUser = "Shoutrrr"
 	// Scheme is the identifying part of this service's configuration URL
 	Scheme = "slack"
 )

--- a/pkg/services/slack/slack_json.go
+++ b/pkg/services/slack/slack_json.go
@@ -1,18 +1,59 @@
 package slack
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // JSON used within the Slack service
 type JSON struct {
-	Text    string `json:"text"`
-	BotName string `json:"username"`
+	Text        string       `json:"text"`
+	BotName     string       `json:"username,omitempty"`
+	Blocks      []block      `json:"blocks,omitempty"`
+	Attachments []attachment `json:"attachments,omitempty"`
+}
+
+type block struct {
+	Type string    `json:"type"`
+	Text blockText `json:"text"`
+}
+
+type blockText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type attachment struct {
+	Title    string        `json:"title,omitempty"`
+	Fallback string        `json:"fallback,omitempty"`
+	Text     string        `json:"text"`
+	Color    string        `json:"color,omitempty"`
+	Fields   []legacyField `json:"fields,omitempty"`
+	Footer   string        `json:"footer,omitempty"`
+	Time     int           `json:"ts,omitempty"`
+}
+
+type legacyField struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+	Short bool   `json:"short,omitempty"`
 }
 
 // CreateJSONPayload compatible with the slack webhook api
 func CreateJSONPayload(config *Config, message string) ([]byte, error) {
+
+	var atts []attachment
+	for _, line := range strings.Split(message, "\n") {
+		atts = append(atts, attachment{
+			Text:  line,
+			Color: config.Color,
+		})
+	}
+
 	return json.Marshal(
 		JSON{
-			Text:    message,
-			BotName: config.BotName,
+			Text:        config.Title,
+			BotName:     config.BotName,
+			Attachments: atts,
 		})
 }

--- a/pkg/services/slack/slack_test.go
+++ b/pkg/services/slack/slack_test.go
@@ -103,6 +103,22 @@ var _ = Describe("the slack service", func() {
 		})
 	})
 	Describe("the slack config", func() {
+		When("parsing the configuration URL", func() {
+			It("should be identical after de-/serialization", func() {
+				testURL := "slack://testbot@AAAAAAAAA/BBBBBBBBB/123456789123456789123456?color=3f00fe&title=Test title"
+
+				url, err := url.Parse(testURL)
+				Expect(err).NotTo(HaveOccurred(), "parsing")
+
+				config := &Config{}
+				err = config.SetURL(url)
+				Expect(err).NotTo(HaveOccurred(), "verifying")
+
+				outputURL := config.GetURL()
+				Expect(outputURL.String()).To(Equal(testURL))
+
+			})
+		})
 		When("generating a config object", func() {
 			It("should use the default botname if the argument list contains three strings", func() {
 				slackURL, _ := url.Parse("slack://AAAAAAAAA/BBBBBBBBB/123456789123456789123456")

--- a/pkg/services/slack/slack_test.go
+++ b/pkg/services/slack/slack_test.go
@@ -41,8 +41,10 @@ var _ = Describe("the slack service", func() {
 			}
 
 			serviceURL, _ := url.Parse(envSlackURL.String())
-			service.Initialize(serviceURL, util.TestLogger())
-			err := service.Send("This is an integration test message", nil)
+			err := service.Initialize(serviceURL, util.TestLogger())
+			Expect(err).NotTo(HaveOccurred())
+
+			err = service.Send("This is an integration test message", nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -106,8 +108,8 @@ var _ = Describe("the slack service", func() {
 				slackURL, _ := url.Parse("slack://AAAAAAAAA/BBBBBBBBB/123456789123456789123456")
 				config, configError := CreateConfigFromURL(slackURL)
 
-				Expect(config.BotName).To(Equal(DefaultUser))
 				Expect(configError).NotTo(HaveOccurred())
+				Expect(config.BotName).To(BeEmpty())
 			})
 			It("should set the botname if the argument list is three", func() {
 				slackURL, _ := url.Parse("slack://testbot@AAAAAAAAA/BBBBBBBBB/123456789123456789123456")

--- a/pkg/services/slack/slack_token.go
+++ b/pkg/services/slack/slack_token.go
@@ -9,6 +9,7 @@ import (
 // Token is a three part string split into A, B and C
 type Token []string
 
+// ValidateToken checks that the token is in the expected format
 func ValidateToken(token Token) error {
 	if err := tokenPartsAreNotEmpty(token); err != nil {
 		return err


### PR DESCRIPTION
- Use legacy `attachments` due to the color support
- Use the normal text field as `title`
- Allow color and title to be set using query and params
- Don't override Bot name by default