### PR TITLE
feat(router): add support for custom service URLs

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -147,12 +147,10 @@ func (router *ServiceRouter) initService(rawURL string) (t.Service, error) {
 		return nil, err
 	}
 
-	serviceFactory, valid := serviceMap[strings.ToLower(scheme)]
-	if !valid {
-		return nil, fmt.Errorf("unknown service scheme for URL '%s'", rawURL)
+	service, err := newService(scheme)
+	if err != nil {
+		return nil, err
 	}
-
-	service := serviceFactory()
 
 	if configURL.Scheme != scheme {
 		router.logger.Println("Got custom URL:", configURL.String())
@@ -176,10 +174,15 @@ func (router *ServiceRouter) initService(rawURL string) (t.Service, error) {
 }
 
 // NewService returns a new uninitialized service instance
-func (router *ServiceRouter) NewService(service string) (t.Service, error) {
-	serviceFactory, valid := serviceMap[strings.ToLower(service)]
+func (*ServiceRouter) NewService(serviceScheme string) (t.Service, error) {
+	return newService(serviceScheme)
+}
+
+// newService returns a new uninitialized service instance
+func newService(serviceScheme string) (t.Service, error) {
+	serviceFactory, valid := serviceMap[strings.ToLower(serviceScheme)]
 	if !valid {
-		return nil, fmt.Errorf("unknown service %q", service)
+		return nil, fmt.Errorf("unknown service %q", serviceScheme)
 	}
 	return serviceFactory(), nil
 }

--- a/pkg/router/router_suite_test.go
+++ b/pkg/router/router_suite_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -53,6 +54,24 @@ var _ = Describe("the router suite", func() {
 			service, err := sr.initService("log+https://hybr.is")
 			Expect(err).To(HaveOccurred())
 			Expect(service).To(BeNil())
+		})
+	})
+
+	Describe("the service map", func() {
+		When("resolving implemented services", func() {
+			services := (&ServiceRouter{}).ListServices()
+
+			for _, scheme := range services {
+				// copy ref to local closure
+				serviceScheme := scheme
+
+				It(fmt.Sprintf("should return a Service for '%s'", serviceScheme), func() {
+					service, err := newService(serviceScheme)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(service).ToNot(BeNil())
+				})
+			}
 		})
 	})
 

--- a/pkg/router/router_suite_test.go
+++ b/pkg/router/router_suite_test.go
@@ -23,22 +23,36 @@ var _ = Describe("the router suite", func() {
 
 	When("extract service name is given a url", func() {
 		It("should extract the protocol/service part", func() {
-			url := "slack://invalid-part"
+			url := "slack://rest/of/url"
 			serviceName, _, err := sr.ExtractServiceName(url)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(serviceName).To(Equal("slack"))
 		})
+		It("should extract the service part when provided in custom form", func() {
+			url := "teams+https://rest/of/url"
+			serviceName, _, err := sr.ExtractServiceName(url)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(serviceName).To(Equal("teams"))
+		})
 		It("should return an error if the protocol/service part is missing", func() {
-			url := "://invalid-part"
+			url := "://rest/of/url"
 			serviceName, _, err := sr.ExtractServiceName(url)
 			Expect(err).To(HaveOccurred())
 			Expect(serviceName).To(Equal(""))
 		})
 		It("should return an error if the protocol/service part is containing invalid letters", func() {
-			url := "a d://invalid-part"
+			url := "a d://rest/of/url"
 			serviceName, _, err := sr.ExtractServiceName(url)
 			Expect(err).To(HaveOccurred())
 			Expect(serviceName).To(Equal(""))
+		})
+	})
+
+	When("initializing a service with a custom URL", func() {
+		It("should return an error if the service does not support it", func() {
+			service, err := sr.initService("log+https://hybr.is")
+			Expect(err).To(HaveOccurred())
+			Expect(service).To(BeNil())
 		})
 	})
 

--- a/pkg/types/custom_url_config.go
+++ b/pkg/types/custom_url_config.go
@@ -1,0 +1,9 @@
+package types
+
+import "net/url"
+
+// CustomURLService is the interface that needs to be implemented to support custom URLs in services
+type CustomURLService interface {
+	Service
+	GetConfigURLFromCustom(customURL *url.URL) (serviceURL *url.URL, err error)
+}


### PR DESCRIPTION
This will allow services to opt in to supporting the `service+custom` URL schema, which can be used for simplifying the setup in  basic scenarios, or to support multiple URL formats.

Example usage by `teams` in #117 :
User get a webhook URL from Teams, and simply prepends `teams+` to the URL to make it a shoutrrr URL:
`teams+https://outlook.office.com/webhook/12345....`