### PR TITLE
fix(send): use StringArray flag for url to not split on commas

### DIFF
--- a/cli/cmd/send/send.go
+++ b/cli/cmd/send/send.go
@@ -9,8 +9,8 @@ import (
 
 	cli "github.com/containrrr/shoutrrr/cli/cmd"
 	u "github.com/containrrr/shoutrrr/internal/util"
-	"github.com/containrrr/shoutrrr/pkg/types"
 	"github.com/containrrr/shoutrrr/pkg/router"
+	"github.com/containrrr/shoutrrr/pkg/types"
 	"github.com/containrrr/shoutrrr/pkg/util"
 )
 
@@ -26,7 +26,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.Flags().BoolP("verbose", "v", false, "")
 
-	Cmd.Flags().StringSliceP("url", "u", []string{}, "The notification url")
+	Cmd.Flags().StringArrayP("url", "u", []string{}, "The notification url")
 	_ = Cmd.MarkFlagRequired("url")
 
 	Cmd.Flags().StringP("message", "m", "", "The message to send to the notification url")
@@ -39,7 +39,7 @@ func init() {
 func Run(cmd *cobra.Command, _ []string) {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 
-	urls, _ := cmd.Flags().GetStringSlice("url")
+	urls, _ := cmd.Flags().GetStringArray("url")
 	message, _ := cmd.Flags().GetString("message")
 	title, _ := cmd.Flags().GetString("title")
 


### PR DESCRIPTION
The `send` cli command uses `StringSlice` for the URL argument which will split the input string by ",". This prevents commas from being used in service URLs which is perfectly valid from other usages.
This will change URL to instead use `StringArray`, which will keep the input intact, but supplying it multiple times adds to the array.
Example:
```
shoutrrr send -u gotify://localhost/token -u logger:// -m Message -t Title
or
shoutrrr send -u gotify://localhost/token Message -u logger:// -t Title
```
(first and second non-flag argument are still URL and Message respectively)