### PR TITLE
feat(service): add generic webhook service

### DIFF
--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -9,12 +9,28 @@ Click on the service for a more thorough explanation.
 | [Pushover](./pushover.md)         | *pushover://shoutrrr:__`apiToken`__@__`userKey`__/?devices=__`device1`__[,__`device2`__, ...]*                                                  |
 | [Slack](./not-documented.md)      | *slack://[__`botname`__@]__`token-a`__/__`token-b`__/__`token-c`__*                                                                             |
 | [Email](./not-documented.md)      | *smtp://__`username`__:__`password`__@__`host`__:__`port`__/?fromAddress=__`fromAddress`__&toAddresses=__`recipient1`__[,__`recipient2`__,...]* |
-| [Microsoft Teams](./teams.md)     | *teams://__`token-a`__/__`token-b`__/__`token-c`__*                                                                                             |
-| [Gotify](./not-documented.md)     | *gotify://__`gotify-host`__/__`token`__*                                                                                                        |
-| [Pushbullet](./not-documented.md) | *pushbullet://__`api-token`__[/__`device`__/#__`channel`__/__`email`__]*                                                                        |
-| [IFTTT](./not-documented.md)      | *ifttt://__`key`__/?events=__`event1`__[,__`event2`__,...]&value1=__`value1`__&value2=__`value2`__&value3=__`value3`__*                         |
-| [Mattermost](./not-documented.md) | *mattermost://[__`username`__@]__`mattermost-host`__/__`token`__[/__`channel`__]*                                                               |
-| [Hangouts Chat](./hangouts.md)    | *hangouts://chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz*                                                                       |
-| [Zulip Chat](./zulip.md)          | *zulip://__`bot-mail`__:__`bot-key`__@__`zulip-domain`__/?stream=__`name-or-id`__&topic=__`name`__*                                             |
-| [Join](./not-documented.md)       | *join://shoutrrr:__`api-key`__@join/?devices=__`device1`__[,__`device2`__, ...][&icon=__`icon`__][&title=__`title`__]*                          |
-| [Rocketchat](./rocketchat.md) | *rocketchat://[__`username`__@]__`rocketchat-host`__/__`token`__[/__`channel`&#124;`@recipient`__]*                                                               |
+| [Microsoft Teams](./teams.md)     | *teams://__`token-a`__/__`token-b`__
+/__`token-c`__*                                                                                             |
+| [Gotify](./not-documented.md)     | *gotify://__`gotify-host`__
+/__`token`__*                                                                                                        |
+| [Pushbullet](./not-documented.md) | *pushbullet:
+//__`api-token`__[/__`device`__/#__`channel`__/__`email`__]*                                                                        |
+| [IFTTT](./not-documented.md)      | *ifttt://__`key`__/?events=__`event1`__[,__`event2`__,...]&value1=__`value1`__
+&value2=__`value2`__&value3=__`value3`__*                         |
+| [Mattermost](./not-documented.md) | *mattermost://[__`username`__@]__`mattermost-host`__
+/__`token`__[/__`channel`__]*                                                               |
+| [Hangouts Chat](./hangouts.md)    | *hangouts:
+//chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz*                                                                       |
+| [Zulip Chat](./zulip.md)          | *zulip://__`bot-mail`__:__`bot-key`__@__`zulip-domain`__/?stream=__`name-or-id`__
+&topic=__`name`__*                                             |
+| [Join](./not-documented.md)       | *join://shoutrrr:__`api-key`__
+@join/?devices=__`device1`__[,__`device2`__, ...][&icon=__`icon`__][&title=__`title`__]*                          |
+| [Rocketchat](./rocketchat.md) | *rocketchat://[__`username`__@]__`rocketchat-host`__/__`token`__[/__`channel`
+&#124;`@recipient`__]*                                                               |
+
+## Specialized services
+
+| Service | Description |
+| ------- | ----------- |
+| [Logger](./not-documented.md) | Writes notification to a configured go `log.Logger` |
+| [Generic Webhook]('./generic.md') | Sends notifications directly to a webhook  |

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -1,36 +1,27 @@
 # Services overview
 
-Click on the service for a more thorough explanation.
+Click on the service for a more thorough explanation. <!-- @formatter:off -->
 
 | Service                           | URL format                                                                                                                                      |
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Discord](./discord.md)           | *discord://__`token`__@__`id`__*                                                                                                           |
+| [Discord](./discord.md)           | *discord://__`token`__@__`id`__*                                                                                                                |
 | [Telegram](./telegram.md)         | *telegram://__`token`__@telegram?channels=__`channel-1`__[,__`channel-2`__,...]*                                                                |
 | [Pushover](./pushover.md)         | *pushover://shoutrrr:__`apiToken`__@__`userKey`__/?devices=__`device1`__[,__`device2`__, ...]*                                                  |
 | [Slack](./not-documented.md)      | *slack://[__`botname`__@]__`token-a`__/__`token-b`__/__`token-c`__*                                                                             |
 | [Email](./not-documented.md)      | *smtp://__`username`__:__`password`__@__`host`__:__`port`__/?fromAddress=__`fromAddress`__&toAddresses=__`recipient1`__[,__`recipient2`__,...]* |
-| [Microsoft Teams](./teams.md)     | *teams://__`token-a`__/__`token-b`__
-/__`token-c`__*                                                                                             |
-| [Gotify](./not-documented.md)     | *gotify://__`gotify-host`__
-/__`token`__*                                                                                                        |
-| [Pushbullet](./not-documented.md) | *pushbullet:
-//__`api-token`__[/__`device`__/#__`channel`__/__`email`__]*                                                                        |
-| [IFTTT](./not-documented.md)      | *ifttt://__`key`__/?events=__`event1`__[,__`event2`__,...]&value1=__`value1`__
-&value2=__`value2`__&value3=__`value3`__*                         |
-| [Mattermost](./not-documented.md) | *mattermost://[__`username`__@]__`mattermost-host`__
-/__`token`__[/__`channel`__]*                                                               |
-| [Hangouts Chat](./hangouts.md)    | *hangouts:
-//chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz*                                                                       |
-| [Zulip Chat](./zulip.md)          | *zulip://__`bot-mail`__:__`bot-key`__@__`zulip-domain`__/?stream=__`name-or-id`__
-&topic=__`name`__*                                             |
-| [Join](./not-documented.md)       | *join://shoutrrr:__`api-key`__
-@join/?devices=__`device1`__[,__`device2`__, ...][&icon=__`icon`__][&title=__`title`__]*                          |
-| [Rocketchat](./rocketchat.md) | *rocketchat://[__`username`__@]__`rocketchat-host`__/__`token`__[/__`channel`
-&#124;`@recipient`__]*                                                               |
+| [Microsoft Teams](./teams.md)     | *teams://__`token-a`__/__`token-b`__/__`token-c`__*                                                                                             |
+| [Gotify](./not-documented.md)     | *gotify://__`gotify-host`__/__`token`__*                                                                                                        |
+| [Pushbullet](./not-documented.md) | *pushbullet://__`api-token`__[/__`device`__/#__`channel`__/__`email`__]*                                                                        |
+| [IFTTT](./not-documented.md)      | *ifttt://__`key`__/?events=__`event1`__[,__`event2`__,...]&value1=__`value1`__&value2=__`value2`__&value3=__`value3`__*                         |
+| [Mattermost](./not-documented.md) | *mattermost://[__`username`__@]__`mattermost-host`__/__`token`__[/__`channel`__]*                                                               |
+| [Hangouts Chat](./hangouts.md)    | *hangouts://chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz*                                                                       |
+| [Zulip Chat](./zulip.md)          | *zulip://__`bot-mail`__:__`bot-key`__@__`zulip-domain`__/?stream=__`name-or-id`__&topic=__`name`__*                                             |
+| [Join](./not-documented.md)       | *join://shoutrrr:__`api-key`__@join/?devices=__`device1`__[,__`device2`__, ...][&icon=__`icon`__][&title=__`title`__]*                          |
+| [Rocketchat](./rocketchat.md)     | *rocketchat://[__`username`__@]__`rocketchat-host`__/__`token`__[/__`channel`&#124;`@recipient`__]*                                             |
 
 ## Specialized services
 
-| Service | Description |
-| ------- | ----------- |
-| [Logger](./not-documented.md) | Writes notification to a configured go `log.Logger` |
-| [Generic Webhook]('./generic.md') | Sends notifications directly to a webhook  |
+| Service                           | Description                                                                                                                                     |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Logger](./not-documented.md)     | Writes notification to a configured go `log.Logger`                                                                                             |
+| [Generic Webhook](./generic.md)   | Sends notifications directly to a webhook                                                                                                       |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - Teams: 'services/teams.md'
       - Telegram: 'services/telegram.md'
       - Zulip Chat: 'services/zulip.md'
+      - Generic Webhook: 'services/generic.md'
   - Advanced usage:
       - Proxy: 'proxy.md'
 

--- a/pkg/format/format_query.go
+++ b/pkg/format/format_query.go
@@ -51,7 +51,7 @@ func BuildQueryWithCustomFields(cqr t.ConfigQueryResolver, query url.Values) url
 // them could not be used to set a config field, and with any escaped keys unescaped.
 // The error returned is the first error that occurred, subsequent errors are just discarded.
 func SetConfigPropsFromQuery(cqr t.ConfigQueryResolver, query url.Values) (url.Values, error) {
-	var firstError error = nil
+	var firstError error
 	if query == nil {
 		return url.Values{}, nil
 	}

--- a/pkg/format/format_query.go
+++ b/pkg/format/format_query.go
@@ -2,23 +2,38 @@ package format
 
 import (
 	"net/url"
+	"strings"
 
-	"github.com/containrrr/shoutrrr/pkg/types"
+	t "github.com/containrrr/shoutrrr/pkg/types"
 )
 
 // BuildQuery converts the fields of a config object to a delimited query string
-func BuildQuery(cqr types.ConfigQueryResolver) string {
-	query := url.Values{}
+func BuildQuery(cqr t.ConfigQueryResolver) string {
+	return BuildQueryWithCustomFields(cqr, url.Values{}).Encode()
+}
+
+// BuildQueryWithCustomFields converts the fields of a config object to a delimited query string,
+// escaping any custom fields that share the same key as a config prop using a "__" prefix
+func BuildQueryWithCustomFields(cqr t.ConfigQueryResolver, query url.Values) url.Values {
 	fields := cqr.QueryFields()
+	skipEscape := len(query) < 1
 
 	pkr, isPkr := cqr.(*PropKeyResolver)
 
 	for _, key := range fields {
+		if !skipEscape {
+			// Escape any webhook query keys using the same name as service props
+			escValues := query[key]
+			if len(escValues) > 0 {
+				query.Del(key)
+				query[EscapeKey(key)] = escValues
+			}
+		}
+
 		if isPkr && !pkr.KeyIsPrimary(key) {
 			continue
 		}
 		value, err := cqr.Get(key)
-
 
 		if err != nil || isPkr && pkr.IsDefault(key, value) {
 			continue
@@ -27,5 +42,51 @@ func BuildQuery(cqr types.ConfigQueryResolver) string {
 		query.Set(key, value)
 	}
 
-	return query.Encode()
+	return query
 }
+
+// SetConfigPropsFromQuery iterates over all the config prop keys and sets the config prop to the corresponding
+// query value based on the key.
+// SetConfigPropsFromQuery returns a non-nil url.Values query with all config prop keys removed, even if any of
+// them could not be used to set a config field, and with any escaped keys unescaped.
+// The error returned is the first error that occurred, subsequent errors are just discarded.
+func SetConfigPropsFromQuery(cqr t.ConfigQueryResolver, query url.Values) (url.Values, error) {
+	var firstError error = nil
+	if query == nil {
+		return url.Values{}, nil
+	}
+	for _, key := range cqr.QueryFields() {
+		// Retrieve the service-related prop value
+		values := query[key]
+		if len(values) > 0 {
+			if err := cqr.Set(key, values[0]); err != nil && firstError == nil {
+				firstError = err
+			}
+		}
+		// Remove it from the query Values
+		query.Del(key)
+
+		// If an escaped version of the key exist, unescape it
+		escKey := EscapeKey(key)
+		escValues := query[escKey]
+		if len(escValues) > 0 {
+			query.Del(escKey)
+			query[key] = escValues
+		}
+	}
+	return query, firstError
+}
+
+// EscapeKey adds the KeyPrefix to custom URL query keys that conflict with service config prop keys
+func EscapeKey(key string) string {
+	return KeyPrefix + key
+}
+
+// UnescapeKey removes the KeyPrefix from custom URL query keys that conflict with service config prop keys
+func UnescapeKey(key string) string {
+	return strings.TrimPrefix(key, KeyPrefix)
+}
+
+// KeyPrefix is the prefix prepended to custom URL query keys that conflict with service config prop keys,
+// consisting of two underscore characters ("__")
+const KeyPrefix = "__"

--- a/pkg/format/format_query_test.go
+++ b/pkg/format/format_query_test.go
@@ -1,0 +1,48 @@
+package format
+
+import (
+	"net/url"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Query Formatter", func() {
+	var pkr PropKeyResolver
+	BeforeEach(func() {
+		ts = &testStruct{}
+		pkr = NewPropKeyResolver(ts)
+		_ = pkr.SetDefaultProps(ts)
+	})
+	Describe("Creating a service URL query from a config", func() {
+		When("a config property has been changed from default", func() {
+			It("should be included in the query string", func() {
+				ts.Str = "test"
+				query := BuildQuery(&pkr)
+				// (pkr, )
+				Expect(query).To(Equal("str=test"))
+			})
+		})
+		When("a custom query key conflicts with a config property key", func() {
+			It("should include both values, with the custom escaped", func() {
+				ts.Str = "service"
+				customQuery := url.Values{"str": {"custom"}}
+				query := BuildQueryWithCustomFields(&pkr, customQuery)
+				Expect(query.Encode()).To(Equal("__str=custom&str=service"))
+			})
+		})
+	})
+	Describe("Setting prop values from query", func() {
+		When("a custom query key conflicts with a config property key", func() {
+			It("should set the config prop from the regular and return the custom one unescaped", func() {
+				ts.Str = "service"
+				serviceQuery := url.Values{"__str": {"custom"}, "str": {"service"}}
+				query, err := SetConfigPropsFromQuery(&pkr, serviceQuery)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ts.Str).To(Equal("service"))
+				Expect(query.Get("str")).To(Equal("custom"))
+			})
+		})
+	})
+
+})

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -2,24 +2,15 @@ package format
 
 import (
 	"errors"
-	"github.com/containrrr/shoutrrr/pkg/types"
 	"github.com/fatih/color"
 	"net/url"
-	"reflect"
-	"strings"
-
 	"testing"
+
+	"github.com/containrrr/shoutrrr/pkg/services/standard"
+	t "github.com/containrrr/shoutrrr/pkg/types"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-)
-
-var (
-	// logger *log.Logger
-	enums = map[string]types.EnumFormatter{
-		"TestEnum": testEnum,
-	}
-	ts *testStruct
 )
 
 func TestFormat(t *testing.T) {
@@ -35,255 +26,67 @@ var _ = Describe("the format package", func() {
 		color.NoColor = true
 	})
 
-	Describe("SetConfigField", func() {
-		var (
-			tv reflect.Value
-		)
-		testConfig := testStruct{}
-		tt := reflect.TypeOf(testConfig)
-		rootNode := getRootNode(&testConfig)
-
-		nodeMap := make(map[string]Node, len(rootNode.Items))
-		for _, item := range rootNode.Items {
-			field := item.Field()
-			nodeMap[field.Name] = item
-		}
-		When("updating a struct", func() {
-
-			BeforeEach(func() {
-				tsPtr := reflect.New(tt)
-				tv = tsPtr.Elem()
-				ts = tsPtr.Interface().(*testStruct)
+	Describe("Generic Format Utils", func() {
+		When("parsing a bool", func() {
+			var testParseValidBool = func(raw string, expected bool) {
+				parsed, ok := ParseBool(raw, !expected)
+				Expect(parsed).To(Equal(expected))
+				Expect(ok).To(BeTrue())
+			}
+			It("should parse truthy values as true", func() {
+				testParseValidBool("true", true)
+				testParseValidBool("1", true)
+				testParseValidBool("yes", true)
 			})
-
-			When("setting an integer value", func() {
-				When("the value is valid", func() {
-					It("should set it", func() {
-						valid, err := SetConfigField(tv, *nodeMap["Signed"].Field(), "3")
-						Expect(valid).To(BeTrue())
-						Expect(err).NotTo(HaveOccurred())
-
-						Expect(ts.Signed).To(Equal(3))
-					})
-				})
-				When("the value is invalid", func() {
-					It("should return an error", func() {
-						ts.Signed = 2
-						valid, err := SetConfigField(tv, *nodeMap["Signed"].Field(), "z7")
-						Expect(valid).To(BeFalse())
-						Expect(err).To(HaveOccurred())
-
-						Expect(ts.Signed).To(Equal(2))
-					})
-				})
+			It("should parse falsy values as false", func() {
+				testParseValidBool("false", false)
+				testParseValidBool("0", false)
+				testParseValidBool("no", false)
 			})
-
-			When("setting an unsigned integer value", func() {
-				When("the value is valid", func() {
-					It("should set it", func() {
-						valid, err := SetConfigField(tv, *nodeMap["Unsigned"].Field(), "6")
-						Expect(valid).To(BeTrue())
-						Expect(err).NotTo(HaveOccurred())
-
-						Expect(ts.Unsigned).To(Equal(uint(6)))
-					})
-				})
-				When("the value is invalid", func() {
-					It("should return an error", func() {
-						ts.Unsigned = 2
-						valid, err := SetConfigField(tv, *nodeMap["Unsigned"].Field(), "-3")
-
-						Expect(ts.Unsigned).To(Equal(uint(2)))
-						Expect(valid).To(BeFalse())
-						Expect(err).To(HaveOccurred())
-					})
-				})
+			It("should match regardless of case", func() {
+				testParseValidBool("trUE", true)
 			})
-
-			When("setting a string slice value", func() {
-				When("the value is valid", func() {
-					It("should set it", func() {
-						valid, err := SetConfigField(tv, *nodeMap["StrSlice"].Field(), "meawannowalkalitabitalleh,meawannofeelalitabitstrongah")
-						Expect(valid).To(BeTrue())
-						Expect(err).NotTo(HaveOccurred())
-
-						Expect(ts.StrSlice).To(HaveLen(2))
-					})
-				})
-			})
-
-			When("setting a string array value", func() {
-				When("the value is valid", func() {
-					It("should set it", func() {
-						valid, err := SetConfigField(tv, *nodeMap["StrArray"].Field(), "meawannowalkalitabitalleh,meawannofeelalitabitstrongah,meawannothinkalitabitsmartah")
-						Expect(valid).To(BeTrue())
-						Expect(err).NotTo(HaveOccurred())
-					})
-				})
-				When("the value has too many elements", func() {
-					It("should return an error", func() {
-						valid, err := SetConfigField(tv, *nodeMap["StrArray"].Field(), "one,two,three,four?")
-						Expect(valid).To(BeFalse())
-						Expect(err).To(HaveOccurred())
-					})
-				})
-				When("the value has too few elements", func() {
-					It("should return an error", func() {
-						valid, err := SetConfigField(tv, *nodeMap["StrArray"].Field(), "one,two")
-						Expect(valid).To(BeFalse())
-						Expect(err).To(HaveOccurred())
-					})
-				})
-			})
-
-			When("setting a struct value", func() {
-				When("it doesn't implement ConfigProp", func() {
-					It("should return an error", func() {
-						valid, err := SetConfigField(tv, *nodeMap["Sub"].Field(), "@awol")
-						Expect(err).To(HaveOccurred())
-						Expect(valid).NotTo(BeTrue())
-					})
-				})
-				When("it implements ConfigProp", func() {
-					When("the value is valid", func() {
-						It("should set it", func() {
-							valid, err := SetConfigField(tv, *nodeMap["SubProp"].Field(), "@awol")
-							Expect(err).NotTo(HaveOccurred())
-							Expect(valid).To(BeTrue())
-
-							Expect(ts.SubProp.Value).To(Equal("awol"))
-						})
-					})
-					When("the value is invalid", func() {
-						It("should return an error", func() {
-							valid, err := SetConfigField(tv, *nodeMap["SubProp"].Field(), "missing initial at symbol")
-							Expect(err).To(HaveOccurred())
-							Expect(valid).NotTo(BeTrue())
-						})
-					})
-				})
-			})
-
-			When("setting a struct slice value", func() {
-				When("the value is valid", func() {
-					It("should set it", func() {
-						valid, err := SetConfigField(tv, *nodeMap["SubPropSlice"].Field(), "@alice,@merton")
-						Expect(err).NotTo(HaveOccurred())
-						Expect(valid).To(BeTrue())
-
-						Expect(ts.SubPropSlice).To(HaveLen(2))
-					})
-				})
-			})
-
-			When("setting a struct pointer slice value", func() {
-				When("the value is valid", func() {
-					It("should set it", func() {
-						valid, err := SetConfigField(tv, *nodeMap["SubPropPtrSlice"].Field(), "@the,@best")
-						Expect(err).NotTo(HaveOccurred())
-						Expect(valid).To(BeTrue())
-
-						Expect(ts.SubPropPtrSlice).To(HaveLen(2))
-					})
-				})
+			It("should return the default if no value matches", func() {
+				parsed, ok := ParseBool("bad", true)
+				Expect(parsed).To(Equal(true))
+				Expect(ok).To(BeFalse())
+				parsed, ok = ParseBool("values", false)
+				Expect(parsed).To(Equal(false))
+				Expect(ok).To(BeFalse())
 			})
 		})
-
-		When("formatting stuct values", func() {
-			BeforeEach(func() {
-				tsPtr := reflect.New(tt)
-				tv = tsPtr.Elem()
+		When("printing a bool", func() {
+			It("should return yes or no", func() {
+				Expect(PrintBool(true)).To(Equal("Yes"))
+				Expect(PrintBool(false)).To(Equal("No"))
 			})
-			When("setting and formatting", func() {
-				It("should format signed integers identical to input", func() {
-					testSetAndFormat(tv, nodeMap["Signed"], "-45", "-45")
-				})
-				It("should format unsigned integers identical to input", func() {
-					testSetAndFormat(tv, nodeMap["Unsigned"], "5", "5")
-				})
-				It("should format structs identical to input", func() {
-					testSetAndFormat(tv, nodeMap["SubProp"], "@whoa", "@whoa")
-				})
-				It("should format enums identical to input", func() {
-					testSetAndFormat(tv, nodeMap["TestEnum"], "Foo", "Foo")
-				})
-				It("should format string slices identical to input", func() {
-					testSetAndFormat(tv, nodeMap["StrSlice"], "one,two,three,four", "[ one, two, three, four ]")
-				})
-				It("should format string arrays identical to input", func() {
-					testSetAndFormat(tv, nodeMap["StrArray"], "one,two,three", "[ one, two, three ]")
-				})
-				It("should format prop struct slices identical to input", func() {
-					testSetAndFormat(tv, nodeMap["SubPropSlice"], "@be,@the,@best", "[ @be, @the, @best ]")
-				})
-				It("should format prop struct pointer slices identical to input", func() {
-					testSetAndFormat(tv, nodeMap["SubPropPtrSlice"], "@diet,@glue", "[ @diet, @glue ]")
-				})
-				It("should format string maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["StrMap"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
-
-				It("should format int maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["IntMap"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
-				It("should format int8 maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["Int8Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
-				It("should format int16 maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["Int16Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
-				It("should format int32 maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["Int32Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
-				It("should format int64 maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["Int64Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
-
-				It("should format uint maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["UintMap"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
-				It("should format uint8 maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["Uint8Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
-				It("should format uint16 maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["Uint16Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
-				It("should format uint32 maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["Uint32Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
-				It("should format uint64 maps identical to input", func() {
-					testSetAndFormat(tv, nodeMap["Uint64Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
-				})
+		})
+		When("checking for number-like strings", func() {
+			It("should be true for numbers", func() {
+				Expect(IsNumber("1.5")).To(BeTrue())
+				Expect(IsNumber("0")).To(BeTrue())
+				Expect(IsNumber("NaN")).To(BeTrue())
 			})
+			It("should be false for non-numbers", func() {
+				Expect(IsNumber("baNaNa")).To(BeFalse())
+			})
+		})
+	})
+	Describe("Enum Formatter", func() {
+		It("should return all enum values on listing", func() {
+			Expect(testEnum.Names()).To(ConsistOf("None", "Foo", "Bar"))
 		})
 	})
 })
 
-func testSetAndFormat(tv reflect.Value, node Node, value string, prettyFormat string) {
-	field := node.Field()
-	_, _ = SetConfigField(tv, *field, value)
-
-	// Used for de-/serializing configuration
-	formatted, err := GetConfigFieldString(tv, *field)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(formatted).To(Equal(value))
-
-	node.Update(tv.FieldByName(field.Name))
-
-	// Used for pretty printing output, coloring etc.
-	sb := strings.Builder{}
-	writeColoredNodeValue(&sb, node)
-	Expect(sb.String()).To(Equal(prettyFormat))
-}
-
 type testStruct struct {
-	Signed          int
+	Signed          int `key:"signed" default:"0"`
 	Unsigned        uint
-	Str             string
+	Str             string `key:"str" default:"notempty"`
 	StrSlice        []string
 	StrArray        [3]string
 	Sub             subStruct
-	TestEnum        int
+	TestEnum        int `key:"testenum" default:"None"`
 	SubProp         subPropStruct
 	SubSlice        []subStruct
 	SubPropSlice    []subPropStruct
@@ -309,7 +112,7 @@ func (t *testStruct) SetURL(_ *url.URL) error {
 	panic("not implemented")
 }
 
-func (t *testStruct) Enums() map[string]types.EnumFormatter {
+func (t *testStruct) Enums() map[string]t.EnumFormatter {
 	return enums
 }
 
@@ -332,4 +135,22 @@ func (s *subPropStruct) GetPropValue() (string, error) {
 	return "@" + s.Value, nil
 }
 
-var testEnum = CreateEnumFormatter([]string{"None", "Foo", "Bar"})
+var (
+	testEnum = CreateEnumFormatter([]string{"None", "Foo", "Bar"})
+	enums    = map[string]t.EnumFormatter{
+		"TestEnum": testEnum,
+	}
+)
+
+type testStructBadDefault struct {
+	standard.EnumlessConfig
+	Value int `key:"value" default:"NaN"`
+}
+
+func (t *testStructBadDefault) GetURL() *url.URL {
+	panic("not implemented")
+}
+
+func (t *testStructBadDefault) SetURL(_ *url.URL) error {
+	panic("not implemented")
+}

--- a/pkg/format/formatter_test.go
+++ b/pkg/format/formatter_test.go
@@ -1,0 +1,254 @@
+package format
+
+import (
+	"reflect"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	// logger *log.Logger
+	ts *testStruct
+)
+
+var _ = Describe("SetConfigField", func() {
+	var (
+		tv reflect.Value
+	)
+	testConfig := testStruct{}
+	tt := reflect.TypeOf(testConfig)
+	rootNode := getRootNode(&testConfig)
+
+	nodeMap := make(map[string]Node, len(rootNode.Items))
+	for _, item := range rootNode.Items {
+		field := item.Field()
+		nodeMap[field.Name] = item
+	}
+	When("updating a struct", func() {
+
+		BeforeEach(func() {
+			tsPtr := reflect.New(tt)
+			tv = tsPtr.Elem()
+			ts = tsPtr.Interface().(*testStruct)
+		})
+
+		When("setting an integer value", func() {
+			When("the value is valid", func() {
+				It("should set it", func() {
+					valid, err := SetConfigField(tv, *nodeMap["Signed"].Field(), "3")
+					Expect(valid).To(BeTrue())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(ts.Signed).To(Equal(3))
+				})
+			})
+			When("the value is invalid", func() {
+				It("should return an error", func() {
+					ts.Signed = 2
+					valid, err := SetConfigField(tv, *nodeMap["Signed"].Field(), "z7")
+					Expect(valid).To(BeFalse())
+					Expect(err).To(HaveOccurred())
+
+					Expect(ts.Signed).To(Equal(2))
+				})
+			})
+		})
+
+		When("setting an unsigned integer value", func() {
+			When("the value is valid", func() {
+				It("should set it", func() {
+					valid, err := SetConfigField(tv, *nodeMap["Unsigned"].Field(), "6")
+					Expect(valid).To(BeTrue())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(ts.Unsigned).To(Equal(uint(6)))
+				})
+			})
+			When("the value is invalid", func() {
+				It("should return an error", func() {
+					ts.Unsigned = 2
+					valid, err := SetConfigField(tv, *nodeMap["Unsigned"].Field(), "-3")
+
+					Expect(ts.Unsigned).To(Equal(uint(2)))
+					Expect(valid).To(BeFalse())
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+
+		When("setting a string slice value", func() {
+			When("the value is valid", func() {
+				It("should set it", func() {
+					valid, err := SetConfigField(tv, *nodeMap["StrSlice"].Field(), "meawannowalkalitabitalleh,meawannofeelalitabitstrongah")
+					Expect(valid).To(BeTrue())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(ts.StrSlice).To(HaveLen(2))
+				})
+			})
+		})
+
+		When("setting a string array value", func() {
+			When("the value is valid", func() {
+				It("should set it", func() {
+					valid, err := SetConfigField(tv, *nodeMap["StrArray"].Field(), "meawannowalkalitabitalleh,meawannofeelalitabitstrongah,meawannothinkalitabitsmartah")
+					Expect(valid).To(BeTrue())
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+			When("the value has too many elements", func() {
+				It("should return an error", func() {
+					valid, err := SetConfigField(tv, *nodeMap["StrArray"].Field(), "one,two,three,four?")
+					Expect(valid).To(BeFalse())
+					Expect(err).To(HaveOccurred())
+				})
+			})
+			When("the value has too few elements", func() {
+				It("should return an error", func() {
+					valid, err := SetConfigField(tv, *nodeMap["StrArray"].Field(), "one,two")
+					Expect(valid).To(BeFalse())
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+
+		When("setting a struct value", func() {
+			When("it doesn't implement ConfigProp", func() {
+				It("should return an error", func() {
+					valid, err := SetConfigField(tv, *nodeMap["Sub"].Field(), "@awol")
+					Expect(err).To(HaveOccurred())
+					Expect(valid).NotTo(BeTrue())
+				})
+			})
+			When("it implements ConfigProp", func() {
+				When("the value is valid", func() {
+					It("should set it", func() {
+						valid, err := SetConfigField(tv, *nodeMap["SubProp"].Field(), "@awol")
+						Expect(err).NotTo(HaveOccurred())
+						Expect(valid).To(BeTrue())
+
+						Expect(ts.SubProp.Value).To(Equal("awol"))
+					})
+				})
+				When("the value is invalid", func() {
+					It("should return an error", func() {
+						valid, err := SetConfigField(tv, *nodeMap["SubProp"].Field(), "missing initial at symbol")
+						Expect(err).To(HaveOccurred())
+						Expect(valid).NotTo(BeTrue())
+					})
+				})
+			})
+		})
+
+		When("setting a struct slice value", func() {
+			When("the value is valid", func() {
+				It("should set it", func() {
+					valid, err := SetConfigField(tv, *nodeMap["SubPropSlice"].Field(), "@alice,@merton")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(valid).To(BeTrue())
+
+					Expect(ts.SubPropSlice).To(HaveLen(2))
+				})
+			})
+		})
+
+		When("setting a struct pointer slice value", func() {
+			When("the value is valid", func() {
+				It("should set it", func() {
+					valid, err := SetConfigField(tv, *nodeMap["SubPropPtrSlice"].Field(), "@the,@best")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(valid).To(BeTrue())
+
+					Expect(ts.SubPropPtrSlice).To(HaveLen(2))
+				})
+			})
+		})
+	})
+
+	When("formatting stuct values", func() {
+		BeforeEach(func() {
+			tsPtr := reflect.New(tt)
+			tv = tsPtr.Elem()
+		})
+		When("setting and formatting", func() {
+			It("should format signed integers identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Signed"], "-45", "-45")
+			})
+			It("should format unsigned integers identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Unsigned"], "5", "5")
+			})
+			It("should format structs identical to input", func() {
+				testSetAndFormat(tv, nodeMap["SubProp"], "@whoa", "@whoa")
+			})
+			It("should format enums identical to input", func() {
+				testSetAndFormat(tv, nodeMap["TestEnum"], "Foo", "Foo")
+			})
+			It("should format string slices identical to input", func() {
+				testSetAndFormat(tv, nodeMap["StrSlice"], "one,two,three,four", "[ one, two, three, four ]")
+			})
+			It("should format string arrays identical to input", func() {
+				testSetAndFormat(tv, nodeMap["StrArray"], "one,two,three", "[ one, two, three ]")
+			})
+			It("should format prop struct slices identical to input", func() {
+				testSetAndFormat(tv, nodeMap["SubPropSlice"], "@be,@the,@best", "[ @be, @the, @best ]")
+			})
+			It("should format prop struct pointer slices identical to input", func() {
+				testSetAndFormat(tv, nodeMap["SubPropPtrSlice"], "@diet,@glue", "[ @diet, @glue ]")
+			})
+			It("should format string maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["StrMap"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+
+			It("should format int maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["IntMap"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+			It("should format int8 maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Int8Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+			It("should format int16 maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Int16Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+			It("should format int32 maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Int32Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+			It("should format int64 maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Int64Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+
+			It("should format uint maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["UintMap"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+			It("should format uint8 maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Uint8Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+			It("should format uint16 maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Uint16Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+			It("should format uint32 maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Uint32Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+			It("should format uint64 maps identical to input", func() {
+				testSetAndFormat(tv, nodeMap["Uint64Map"], "a:1,b:2,c:3", "{ a: 1, b: 2, c: 3 }")
+			})
+		})
+	})
+})
+
+func testSetAndFormat(tv reflect.Value, node Node, value string, prettyFormat string) {
+	field := node.Field()
+	_, _ = SetConfigField(tv, *field, value)
+
+	// Used for de-/serializing configuration
+	formatted, err := GetConfigFieldString(tv, *field)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(formatted).To(Equal(value))
+
+	node.Update(tv.FieldByName(field.Name))
+
+	// Used for pretty printing output, coloring etc.
+	sb := strings.Builder{}
+	writeColoredNodeValue(&sb, node)
+	Expect(sb.String()).To(Equal(prettyFormat))
+}

--- a/pkg/format/prop_key_resolver.go
+++ b/pkg/format/prop_key_resolver.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/containrrr/shoutrrr/pkg/types"
+	t "github.com/containrrr/shoutrrr/pkg/types"
 )
 
 // PropKeyResolver implements the ConfigQueryResolver interface for services that uses key tags for query props
@@ -18,7 +18,7 @@ type PropKeyResolver struct {
 }
 
 // NewPropKeyResolver creates a new PropKeyResolver and initializes it using the provided config
-func NewPropKeyResolver(config types.ServiceConfig) PropKeyResolver {
+func NewPropKeyResolver(config t.ServiceConfig) PropKeyResolver {
 
 	configNode := GetConfigFormat(config)
 	items := configNode.Items
@@ -83,40 +83,47 @@ func (pkr *PropKeyResolver) set(target reflect.Value, key string, value string) 
 }
 
 // UpdateConfigFromParams mutates the provided config, updating the values from it's corresponding params
-func (pkr *PropKeyResolver) UpdateConfigFromParams(config types.ServiceConfig, params *types.Params) error {
+// If the provided config is nil, the internal config will be updated instead.
+// The error returned is the first error that occurred, subsequent errors are just discarded.
+func (pkr *PropKeyResolver) UpdateConfigFromParams(config t.ServiceConfig, params *t.Params) (firstError error) {
+	confValue := pkr.configValueOrInternal(config)
 	if params != nil {
 		for key, val := range *params {
-			if err := pkr.set(reflect.Indirect(reflect.ValueOf(config)), key, val); err != nil {
-				return err
+			if err := pkr.set(confValue, key, val); err != nil && firstError == nil {
+				firstError = err
 			}
 		}
 	}
-	return nil
+	return
 }
 
 // SetDefaultProps mutates the provided config, setting the tagged fields with their default values
-func (pkr *PropKeyResolver) SetDefaultProps(config types.ServiceConfig) error {
+// If the provided config is nil, the internal config will be updated instead.
+// The error returned is the first error that occurred, subsequent errors are just discarded.
+func (pkr *PropKeyResolver) SetDefaultProps(config t.ServiceConfig) (firstError error) {
+	confValue := pkr.configValueOrInternal(config)
 	for key, info := range pkr.keyFields {
-		if err := pkr.set(reflect.Indirect(reflect.ValueOf(config)), key, info.DefaultValue); err != nil {
-			return err
+		if err := pkr.set(confValue, key, info.DefaultValue); err != nil && firstError == nil {
+			firstError = err
 		}
 	}
-	return nil
+	return
 }
 
-// Bind is called to set the internal config reference for the PropKeyResolver
-func (pkr *PropKeyResolver) Bind(config types.ServiceConfig) PropKeyResolver {
+// Bind is called to create a new instance of the PropKeyResolver, with he internal config reference
+// set to the provided config. This should only be used for configs of the same type.
+func (pkr *PropKeyResolver) Bind(config t.ServiceConfig) PropKeyResolver {
 	bound := *pkr
-	bound.confValue = reflect.ValueOf(config)
+	bound.confValue = configValue(config)
 	return bound
 }
 
 // GetConfigQueryResolver returns the config itself if it implements ConfigQueryResolver
 // otherwise it creates and returns a PropKeyResolver that implements it
-func GetConfigQueryResolver(config types.ServiceConfig) types.ConfigQueryResolver {
-	var resolver types.ConfigQueryResolver
+func GetConfigQueryResolver(config t.ServiceConfig) t.ConfigQueryResolver {
+	var resolver t.ConfigQueryResolver
 	var ok bool
-	if resolver, ok = config.(types.ConfigQueryResolver); !ok {
+	if resolver, ok = config.(t.ConfigQueryResolver); !ok {
 		pkr := NewPropKeyResolver(config)
 		resolver = &pkr
 	}
@@ -126,6 +133,17 @@ func GetConfigQueryResolver(config types.ServiceConfig) types.ConfigQueryResolve
 // KeyIsPrimary returns whether the key is the primary (and not an alias)
 func (pkr *PropKeyResolver) KeyIsPrimary(key string) bool {
 	return pkr.keyFields[key].Keys[0] == key
+}
+
+func (pkr *PropKeyResolver) configValueOrInternal(config t.ServiceConfig) reflect.Value {
+	if config != nil {
+		return configValue(config)
+	}
+	return pkr.confValue
+}
+
+func configValue(config t.ServiceConfig) reflect.Value {
+	return reflect.Indirect(reflect.ValueOf(config))
 }
 
 // IsDefault returns whether the specified key value is the default value

--- a/pkg/format/prop_key_resolver_test.go
+++ b/pkg/format/prop_key_resolver_test.go
@@ -1,0 +1,55 @@
+package format
+
+import (
+	t "github.com/containrrr/shoutrrr/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Prop Key Resolver", func() {
+	var (
+		ts  *testStruct
+		pkr PropKeyResolver
+	)
+	BeforeEach(func() {
+		ts = &testStruct{}
+		pkr = NewPropKeyResolver(ts)
+		_ = pkr.SetDefaultProps(ts)
+	})
+	Describe("Updating config props from params", func() {
+		When("a param matches a prop key", func() {
+			It("should be updated in the config", func() {
+				err := pkr.UpdateConfigFromParams(nil, &t.Params{"str": "newValue"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ts.Str).To(Equal("newValue"))
+			})
+		})
+		When("a param does not match a prop key", func() {
+			It("should report the first error", func() {
+				err := pkr.UpdateConfigFromParams(nil, &t.Params{"a": "z"})
+				Expect(err).To(HaveOccurred())
+			})
+			It("should process the other keys", func() {
+				_ = pkr.UpdateConfigFromParams(nil, &t.Params{"signed": "1", "b": "c", "str": "val"})
+				Expect(ts.Signed).To(Equal(1))
+				Expect(ts.Str).To(Equal("val"))
+			})
+		})
+	})
+	Describe("Setting default props", func() {
+		When("a default tag are set for a field", func() {
+			It("should have that value as default", func() {
+				Expect(ts.Str).To(Equal("notempty"))
+			})
+		})
+		When("a default tag have an invalid value", func() {
+			It("should have that value as default", func() {
+				tsb := &testStructBadDefault{}
+				pkr = NewPropKeyResolver(tsb)
+				err := pkr.SetDefaultProps(tsb)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+})

--- a/pkg/router/servicemap.go
+++ b/pkg/router/servicemap.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"github.com/containrrr/shoutrrr/pkg/services/discord"
+	"github.com/containrrr/shoutrrr/pkg/services/generic"
 	"github.com/containrrr/shoutrrr/pkg/services/gotify"
 	"github.com/containrrr/shoutrrr/pkg/services/hangouts"
 	"github.com/containrrr/shoutrrr/pkg/services/ifttt"
@@ -39,4 +40,5 @@ var serviceMap = map[string]func() t.Service{
 	"join":       func() t.Service { return &join.Service{} },
 	"rocketchat": func() t.Service { return &rocketchat.Service{} },
 	"opsgenie":   func() t.Service { return &opsgenie.Service{} },
+	"generic":    func() t.Service { return &generic.Service{} },
 }

--- a/pkg/services/generic/generic.go
+++ b/pkg/services/generic/generic.go
@@ -1,0 +1,92 @@
+package generic
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/services/standard"
+	"github.com/containrrr/shoutrrr/pkg/types"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Service providing a generic notification service
+type Service struct {
+	standard.Standard
+	config *Config
+	pkr    format.PropKeyResolver
+}
+
+// Send a notification message to a generic webhook endpoint
+func (service *Service) Send(message string, params *types.Params) error {
+	config := service.config
+
+	if err := service.pkr.UpdateConfigFromParams(config, params); err != nil {
+		service.Logf("Failed to update params: %v", err)
+	}
+
+	if err := service.doSend(config, message, params); err != nil {
+		return fmt.Errorf("an error occurred while sending notification to generic webhook: %s", err.Error())
+	}
+
+	return nil
+}
+
+// Initialize loads ServiceConfig from configURL and sets logger for this Service
+func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+	service.Logger.SetLogger(logger)
+	config, pkr := DefaultConfig()
+	service.config = config
+	service.pkr = pkr
+
+	return service.config.setURL(&service.pkr, configURL)
+}
+
+// GetConfigURLFromCustom creates a regular service URL from one with a custom host
+func (*Service) GetConfigURLFromCustom(customURL *url.URL) (serviceURL *url.URL, err error) {
+	webhookURL := *customURL
+	if strings.HasPrefix(webhookURL.Scheme, Scheme) {
+		webhookURL.Scheme = webhookURL.Scheme[len(Scheme)+1:]
+	}
+	config, pkr, err := ConfigFromWebhookURL(webhookURL)
+	if err != nil {
+		return nil, err
+	}
+	return config.getURL(&pkr), nil
+}
+
+func (service *Service) doSend(config *Config, message string, params *types.Params) error {
+	postURL := config.WebhookURL().String()
+	payload, err := service.getPayload(config.Template, message, params)
+	if err != nil {
+		return err
+	}
+
+	res, err := http.Post(postURL, config.ContentType, payload)
+	if err == nil && res.StatusCode != http.StatusOK {
+		err = fmt.Errorf("server returned response status code %s", res.Status)
+	}
+
+	return err
+}
+
+func (service *Service) getPayload(template string, message string, params *types.Params) (io.Reader, error) {
+	if template == "" {
+		return bytes.NewBufferString(message), nil
+	}
+	tpl, found := service.GetTemplate(template)
+	if !found {
+		return nil, fmt.Errorf("template %q has not been loaded", template)
+	}
+
+	if params == nil {
+		params = &types.Params{}
+	}
+	params.SetMessage(message)
+	bb := &bytes.Buffer{}
+	err := tpl.Execute(bb, params)
+	return bb, err
+}

--- a/pkg/services/generic/generic_config.go
+++ b/pkg/services/generic/generic_config.go
@@ -1,0 +1,95 @@
+package generic
+
+import (
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/services/standard"
+	t "github.com/containrrr/shoutrrr/pkg/types"
+	"net/url"
+)
+
+// Config for use within the generic service
+type Config struct {
+	standard.EnumlessConfig
+	webhookURL  *url.URL
+	ContentType string `key:"contenttype" default:"application/json" desc:"The value of the Content-Type header"`
+	DisableTLS  bool   `key:"disabletls" default:"No"`
+	Template    string `key:"template" optional:""`
+	Title       string `key:"title" default:""`
+}
+
+// DefaultConfig creates a PropKeyResolver and uses it to populate the default values of a new Config, returning both
+func DefaultConfig() (*Config, format.PropKeyResolver) {
+	config := &Config{}
+	pkr := format.NewPropKeyResolver(config)
+	_ = pkr.SetDefaultProps(config)
+	return config, pkr
+}
+
+// ConfigFromWebhookURL creates a new Config from a parsed Webhook URL
+func ConfigFromWebhookURL(webhookURL url.URL) (*Config, format.PropKeyResolver, error) {
+	config, pkr := DefaultConfig()
+
+	config.webhookURL = &webhookURL
+	// TODO: Decide what to do with custom URL queries. Right now they are passed
+	//       to the inner url.URL and not processed by PKR.
+	// customQuery, err := format.SetConfigPropsFromQuery(&pkr, webhookURL.Query())
+	// goland:noinspection GoNilness: SetConfigPropsFromQuery always return non-nil
+	// config.webhookURL.RawQuery = customQuery.Encode()
+	config.DisableTLS = webhookURL.Scheme == "http"
+	return config, pkr, nil
+}
+
+// WebhookURL returns a url.URL that is synchronized with the config props
+func (config *Config) WebhookURL() *url.URL {
+	webhookURL := *config.webhookURL
+	webhookURL.Scheme = DefaultWebhookScheme
+	if config.DisableTLS {
+		webhookURL.Scheme = webhookURL.Scheme[:4]
+	}
+	return &webhookURL
+}
+
+// GetURL returns a URL representation of it's current field values
+func (config *Config) GetURL() *url.URL {
+	resolver := format.NewPropKeyResolver(config)
+	return config.getURL(&resolver)
+}
+
+// SetURL updates a ServiceConfig from a URL representation of it's field values
+func (config *Config) SetURL(serviceURL *url.URL) error {
+	resolver := format.NewPropKeyResolver(config)
+	return config.setURL(&resolver, serviceURL)
+}
+
+func (config *Config) getURL(resolver t.ConfigQueryResolver) *url.URL {
+
+	serviceURL := *config.webhookURL
+	webhookQuery := config.webhookURL.Query()
+	serviceQuery := format.BuildQueryWithCustomFields(resolver, webhookQuery)
+	serviceURL.RawQuery = serviceQuery.Encode()
+	serviceURL.Scheme = Scheme
+
+	return &serviceURL
+}
+
+func (config *Config) setURL(resolver t.ConfigQueryResolver, serviceURL *url.URL) error {
+
+	webhookURL := *serviceURL
+	serviceQuery := serviceURL.Query()
+
+	customQuery, err := format.SetConfigPropsFromQuery(resolver, serviceQuery)
+	if err != nil {
+		return err
+	}
+	webhookURL.RawQuery = customQuery.Encode()
+	config.webhookURL = &webhookURL
+
+	return nil
+}
+
+const (
+	// Scheme is the identifying part of this service's configuration URL
+	Scheme = "generic"
+	// DefaultWebhookScheme is the scheme used for webhook URLs unless overridden
+	DefaultWebhookScheme = "https"
+)

--- a/pkg/services/generic/generic_test.go
+++ b/pkg/services/generic/generic_test.go
@@ -1,0 +1,235 @@
+package generic
+
+import (
+	"errors"
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
+	"github.com/jarcoal/httpmock"
+	"io/ioutil"
+	"log"
+	"net/url"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGeneric(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoutrrr Generic Webhook Suite")
+}
+
+var (
+	logger  = log.New(GinkgoWriter, "Test", log.LstdFlags)
+	service *Service
+)
+
+var _ = Describe("the Generic service", func() {
+	BeforeEach(func() {
+		service = &Service{}
+		service.SetLogger(logger)
+	})
+	When("parsing a custom URL", func() {
+		It("should strip generic prefix before parsing", func() {
+			customURL, err := url.Parse("generic+https://test.tld")
+			Expect(err).NotTo(HaveOccurred())
+			actualURL, err := service.GetConfigURLFromCustom(customURL)
+			Expect(err).NotTo(HaveOccurred())
+			_, expectedURL := testCustomURL("https://test.tld")
+			Expect(actualURL.String()).To(Equal(expectedURL.String()))
+		})
+
+		When("a HTTP URL is provided", func() {
+			It("should disable TLS", func() {
+				config, _ := testCustomURL("http://example.com")
+				Expect(config.DisableTLS).To(BeTrue())
+			})
+		})
+		When("a HTTPS URL is provided", func() {
+			It("should enable TLS", func() {
+				config, _ := testCustomURL("https://example.com")
+				Expect(config.DisableTLS).To(BeFalse())
+			})
+		})
+		It("should escape conflicting custom query keys", func() {
+			expectedURL := "generic://example.com/?__template=passed"
+			config, srvURL := testCustomURL("https://example.com/?template=passed")
+			Expect(config.Template).NotTo(Equal("passed")) // captured
+			whURL := config.WebhookURL().String()
+			Expect(whURL).To(Equal("https://example.com/?template=passed"))
+			Expect(srvURL.String()).To(Equal(expectedURL))
+
+		})
+		It("should handle both escaped and service prop version of keys", func() {
+			config, _ := testServiceURL("generic://example.com/?__template=passed&template=captured")
+			Expect(config.Template).To(Equal("captured"))
+			whURL := config.WebhookURL().String()
+			Expect(whURL).To(Equal("https://example.com/?template=passed"))
+		})
+	})
+	When("retrieving the webhook URL", func() {
+		It("should build a valid webhook URL", func() {
+			expectedURL := "https://example.com/path?foo=bar"
+			config, _ := testServiceURL("generic://example.com/path?foo=bar")
+			Expect(config.WebhookURL().String()).To(Equal(expectedURL))
+		})
+
+		When("TLS is disabled", func() {
+			It("should use http schema", func() {
+				config := Config{
+					webhookURL: &url.URL{
+						Host: "test.tld",
+					},
+					DisableTLS: true,
+				}
+				Expect(config.WebhookURL().Scheme).To(Equal("http"))
+			})
+		})
+		When("TLS is not disabled", func() {
+			It("should use https schema", func() {
+				config := Config{
+					webhookURL: &url.URL{
+						Host: "test.tld",
+					},
+					DisableTLS: false,
+				}
+				Expect(config.WebhookURL().Scheme).To(Equal("https"))
+			})
+		})
+	})
+
+	Describe("creating a config", func() {
+		When("creating a default config", func() {
+			It("should not return an error", func() {
+				config := &Config{}
+				pkr := format.NewPropKeyResolver(config)
+				err := pkr.SetDefaultProps(config)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("parsing the configuration URL", func() {
+			It("should be identical after de-/serialization", func() {
+				testURL := "generic://user:pass@host.tld/api/v1/webhook?__title=w&contenttype=a%2Fb&template=f&title=t"
+
+				url, err := url.Parse(testURL)
+				Expect(err).NotTo(HaveOccurred(), "parsing")
+
+				config := &Config{}
+				err = config.SetURL(url)
+				Expect(err).NotTo(HaveOccurred(), "verifying")
+
+				outputURL := config.GetURL()
+				Expect(outputURL.String()).To(Equal(testURL))
+
+			})
+		})
+	})
+
+	Describe("building the payload", func() {
+		var service Service
+		BeforeEach(func() {
+			service = Service{}
+		})
+		When("no template is specified", func() {
+			It("should use the message as payload", func() {
+				payload, err := service.getPayload("", "test message", nil)
+				Expect(err).NotTo(HaveOccurred())
+				contents, err := ioutil.ReadAll(payload)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(contents)).To(Equal("test message"))
+			})
+		})
+		When("a valid template is specified", func() {
+			It("should apply the template to the message payload", func() {
+				err := service.SetTemplateString("news", `{{.title}} ==> {{.message}}`)
+				Expect(err).NotTo(HaveOccurred())
+				params := types.Params{}
+				params.SetTitle("BREAKING NEWS")
+				payload, err := service.getPayload("news", "it's today!", &params)
+				Expect(err).NotTo(HaveOccurred())
+				contents, err := ioutil.ReadAll(payload)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(contents)).To(Equal("BREAKING NEWS ==> it's today!"))
+			})
+			When("given nil params", func() {
+				It("should apply template with message data", func() {
+					err := service.SetTemplateString("arrows", `==> {{.message}} <==`)
+					Expect(err).NotTo(HaveOccurred())
+					payload, err := service.getPayload("arrows", "LOOK AT ME", nil)
+					Expect(err).NotTo(HaveOccurred())
+					contents, err := ioutil.ReadAll(payload)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(contents)).To(Equal("==> LOOK AT ME <=="))
+				})
+			})
+		})
+		When("an unknown template is specified", func() {
+			It("should return an error", func() {
+				_, err := service.getPayload("missing", "test message", nil)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+	})
+	Describe("sending the payload", func() {
+		var err error
+		var service Service
+		BeforeEach(func() {
+			httpmock.Activate()
+		})
+		AfterEach(func() {
+			httpmock.DeactivateAndReset()
+		})
+
+		It("should not report an error if the server accepts the payload", func() {
+			serviceURL, _ := url.Parse("generic://host.tld/webhook")
+			err = service.Initialize(serviceURL, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			targetURL := "https://host.tld/webhook"
+			httpmock.RegisterResponder("POST", targetURL, httpmock.NewStringResponder(200, ""))
+
+			err = service.Send("Message", nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should not panic if an error occurs when sending the payload", func() {
+			serviceURL, _ := url.Parse("generic://host.tld/webhook")
+			err = service.Initialize(serviceURL, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			targetURL := "https://host.tld/webhook"
+			httpmock.RegisterResponder("POST", targetURL, httpmock.NewErrorResponder(errors.New("dummy error")))
+
+			err = service.Send("Message", nil)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should not return an error when an unknown param is encountered", func() {
+			serviceURL, _ := url.Parse("generic://host.tld/webhook")
+			err = service.Initialize(serviceURL, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			targetURL := "https://host.tld/webhook"
+			httpmock.RegisterResponder("POST", targetURL, httpmock.NewStringResponder(200, ""))
+
+			err = service.Send("Message", &types.Params{"unknown": "param"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
+func testCustomURL(testURL string) (*Config, *url.URL) {
+	customURL, err := url.Parse(testURL)
+	Expect(err).NotTo(HaveOccurred())
+	config, pkr, err := ConfigFromWebhookURL(*customURL)
+	Expect(err).NotTo(HaveOccurred())
+	return config, config.getURL(&pkr)
+}
+
+func testServiceURL(testURL string) (*Config, *url.URL) {
+	serviceURL, err := url.Parse(testURL)
+	Expect(err).NotTo(HaveOccurred())
+	config, pkr := DefaultConfig()
+	err = config.setURL(&pkr, serviceURL)
+	Expect(err).NotTo(HaveOccurred())
+	return config, config.getURL(&pkr)
+}

--- a/pkg/types/params.go
+++ b/pkg/types/params.go
@@ -3,7 +3,10 @@ package types
 // Params is the string map used to provide additional variables to the service templates
 type Params map[string]string
 
-const titleKey = "title"
+const (
+	titleKey   = "title"
+	messageKey = "message"
+)
 
 // SetTitle sets the "title" param to the specified value
 func (p Params) SetTitle(title string) {
@@ -14,4 +17,9 @@ func (p Params) SetTitle(title string) {
 func (p Params) Title() (title string, found bool) {
 	title, found = p[titleKey]
 	return
+}
+
+// SetMessage sets the "message" param to the specified value
+func (p Params) SetMessage(message string) {
+	p[messageKey] = message
 }


### PR DESCRIPTION
This adds a custom webhook service that just posts the `message` to the URL that corresponds to the URL.

To use it with another format, set the `template` query field (`generic://example.com/api/webhook?template=TEMPLATE_ID` or pass it as a param to `Send`:
```go
err = service.Send("Message", &types.Params{"template": "TEMPLATE_ID"})
```

The templates are loaded into the service by using either
```go
err := service.SetTemplateString("TEMPLATE_ID", `{{.message}}`)
```
or
```go
err := service.SetTemplateFile("TEMPLATE_ID", "/path/to/template.file")
```

Where `TEMPLATE_ID` can be anything.