### PR TITLE
docs(discord): add props usage

### DIFF
--- a/docs/services/discord.md
+++ b/docs/services/discord.md
@@ -8,6 +8,21 @@ Your Discord Webhook-URL will look like this:
 The shoutrrr service URL should look like this:  
 > discord://__`token`__@__`channel`__
 
+## Additional props
+
+*Can be either supplied using the params argument, or through the URL using ?key=value&key=value etc.*.
+
+ * **Title**  
+   Type: *string*, Default: _empty_
+ * **Username** - Override the webhook default username
+    Type: *string*, Default: _empty_
+ * **AvatarURL** - Override the webhook default avatar  
+   Type: *string*, Default: _empty_        
+ * **Color** - The color of the left border for plain messages
+   Type: *number*, Default: 0x50D9ff
+ * **SplitLines** - Whether to send each line as a separate message item  
+   Type: *boolean*, Default: yes
+
 ## Creating a webhook in Discord
 
 1. Open your server settings by first clicking on the name of the server.


### PR DESCRIPTION
The added props to the discord service where not documented. This adds the useful ones to the docs (the additional colors cannot be used in any meaningful way right now, so documenting them would just lead to confusion).