### PR TITLE
fix(discord): rename channel into webhook ID

### DIFF
--- a/pkg/services/discord/discord.go
+++ b/pkg/services/discord/discord.go
@@ -106,7 +106,7 @@ func CreateAPIURLFromConfig(config *Config) string {
 	return fmt.Sprintf(
 		"%s/%s/%s",
 		hookURL,
-		config.Channel,
+		config.WebhookID,
 		config.Token)
 }
 

--- a/pkg/services/discord/discord_config.go
+++ b/pkg/services/discord/discord_config.go
@@ -11,7 +11,7 @@ import (
 // Config is the configuration needed to send discord notifications
 type Config struct {
 	standard.EnumlessConfig
-	Channel    string
+	WebhookID  string
 	Token      string
 	Title      string `key:"title"      default:""`
 	Username   string `key:"username"   default:""        desc:"Override the webhook default username"`
@@ -51,7 +51,7 @@ func (config *Config) SetURL(url *url.URL) error {
 func (config *Config) getURL(resolver types.ConfigQueryResolver) (u *url.URL) {
 	u = &url.URL{
 		User:       url.User(config.Token),
-		Host:       config.Channel,
+		Host:       config.WebhookID,
 		Scheme:     Scheme,
 		RawQuery:   format.BuildQuery(resolver),
 		ForceQuery: false,
@@ -67,7 +67,7 @@ func (config *Config) getURL(resolver types.ConfigQueryResolver) (u *url.URL) {
 // SetURL updates a ServiceConfig from a URL representation of it's field values
 func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) error {
 
-	config.Channel = url.Host
+	config.WebhookID = url.Host
 	config.Token = url.User.Username()
 
 	if len(url.Path) > 0 {
@@ -80,8 +80,8 @@ func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) e
 		}
 	}
 
-	if config.Channel == "" {
-		return errors.New("channel missing from config URL")
+	if config.WebhookID == "" {
+		return errors.New("webhook ID missing from config URL")
 	}
 
 	if len(config.Token) < 1 {

--- a/pkg/services/discord/discord_test.go
+++ b/pkg/services/discord/discord_test.go
@@ -212,8 +212,8 @@ var _ = Describe("the discord service", func() {
 		})
 		It("should not report an error if the server accepts the payload", func() {
 			config := Config{
-				Channel: "1",
-				Token:   "dummyToken",
+				WebhookID: "1",
+				Token:     "dummyToken",
 			}
 			serviceURL := config.GetURL()
 			service := Service{}


### PR DESCRIPTION
Note: Breaking change for anything explicitly passing a config struct to the discord service (which should normally never be the case).

fixes #156 