### PR TITLE
Assert service compliance

### DIFF
--- a/pkg/services/gotify/gotify.go
+++ b/pkg/services/gotify/gotify.go
@@ -21,7 +21,7 @@ type Service struct {
 	standard.Standard
 	config *Config
 	pkr    format.PropKeyResolver
-	client *http.Client
+	Client *http.Client
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
@@ -33,7 +33,7 @@ func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error
 	service.pkr = format.NewPropKeyResolver(service.config)
 	err := service.config.SetURL(configURL)
 
-	service.client = &http.Client{
+	service.Client = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				// If DisableTLS is specified, we might still need to disable TLS verification
@@ -106,7 +106,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 		return err
 	}
 	jsonBuffer := bytes.NewBuffer(jsonBody)
-	resp, err := service.client.Post(postURL, "application/json", jsonBuffer)
+	resp, err := service.Client.Post(postURL, "application/json", jsonBuffer)
 	if err != nil {
 		return fmt.Errorf("failed to send notification to Gotify: %s", err)
 	}

--- a/pkg/services/gotify/gotify_test.go
+++ b/pkg/services/gotify/gotify_test.go
@@ -119,7 +119,7 @@ var _ = Describe("the Gotify plugin URL building and token validation functions"
 		It("should not report an error if the server accepts the payload", func() {
 			serviceURL, _ := url.Parse("gotify://my.gotify.tld/Aaa.bbb.ccc.ddd")
 			err = service.Initialize(serviceURL, logger)
-			httpmock.ActivateNonDefault(service.client)
+			httpmock.ActivateNonDefault(service.Client)
 			Expect(err).NotTo(HaveOccurred())
 
 			targetURL := "https://my.gotify.tld/message?token=Aaa.bbb.ccc.ddd"
@@ -131,7 +131,7 @@ var _ = Describe("the Gotify plugin URL building and token validation functions"
 		It("should not panic if an error occurs when sending the payload", func() {
 			serviceURL, _ := url.Parse("gotify://my.gotify.tld/Aaa.bbb.ccc.ddd")
 			err = service.Initialize(serviceURL, logger)
-			httpmock.ActivateNonDefault(service.client)
+			httpmock.ActivateNonDefault(service.Client)
 			Expect(err).NotTo(HaveOccurred())
 
 			targetURL := "https://my.gotify.tld/message?token=Aaa.bbb.ccc.ddd"

--- a/pkg/services/ifttt/ifttt_config.go
+++ b/pkg/services/ifttt/ifttt_config.go
@@ -16,12 +16,14 @@ const (
 // Config is the configuration needed to send IFTTT notifications
 type Config struct {
 	standard.EnumlessConfig
-	WebHookID         string
-	Events            []string `key:"events"`
+	WebHookID         string   `required:"true"`
+	Events            []string `key:"events" required:"true"`
 	Value1            string   `key:"value1"`
 	Value2            string   `key:"value2"`
 	Value3            string   `key:"value3"`
-	UseMessageAsValue uint8    `key:"messagevalue" desc:"" default:"2"`
+	UseMessageAsValue uint8    `key:"messagevalue" desc:"sets the corresponding value field to the notification message" default:"2"`
+	UseTitleAsValue   uint8    `key:"titlevalue" desc:"sets the corresponding value field to the notification title" default:"0"`
+	Title             string   `key:"title" default:"" desc:"notification title, optionally set by the sender"`
 }
 
 // GetURL returns a URL representation of it's current field values
@@ -60,6 +62,14 @@ func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) e
 
 	if config.UseMessageAsValue > 3 || config.UseMessageAsValue < 1 {
 		return errors.New("invalid value for messagevalue: only values 1-3 are supported")
+	}
+
+	if config.UseTitleAsValue > 3 {
+		return errors.New("invalid value for titlevalue: only values 1-3 or 0 (for disabling) are supported")
+	}
+
+	if config.UseTitleAsValue == config.UseMessageAsValue {
+		return errors.New("titlevalue cannot use the same number as messagevalue")
 	}
 
 	if len(config.Events) < 1 {

--- a/pkg/services/opsgenie/opsgenie.go
+++ b/pkg/services/opsgenie/opsgenie.go
@@ -68,12 +68,12 @@ func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error
 // See: https://docs.opsgenie.com/docs/alert-api#create-alert
 func (service *Service) Send(message string, params *types.Params) error {
 	config := service.config
-	url := fmt.Sprintf(alertEndpointTemplate, config.Host, config.Port)
+	endpointURL := fmt.Sprintf(alertEndpointTemplate, config.Host, config.Port)
 	payload, err := service.newAlertPayload(message, params)
 	if err != nil {
 		return err
 	}
-	return service.sendAlert(url, config.APIKey, payload)
+	return service.sendAlert(endpointURL, config.APIKey, payload)
 }
 
 func (service *Service) newAlertPayload(message string, params *types.Params) (AlertPayload, error) {
@@ -88,10 +88,27 @@ func (service *Service) newAlertPayload(message string, params *types.Params) (A
 		return AlertPayload{}, err
 	}
 
+	// Use `Message` for the title if available, or if the message is too long
+	// Use `Description` for the message in these scenarios
+	title := payloadFields.Title
+	description := message
+	if title == "" {
+		if len(message) > 130 {
+			title = message[:130]
+		} else {
+			title = message
+			description = ""
+		}
+	}
+
+	if payloadFields.Description != "" && description != "" {
+		description = description + "\n"
+	}
+
 	result := AlertPayload{
-		Message:     message,
+		Message:     title,
 		Alias:       payloadFields.Alias,
-		Description: payloadFields.Description,
+		Description: description + payloadFields.Description,
 		Responders:  payloadFields.Responders,
 		VisibleTo:   payloadFields.VisibleTo,
 		Actions:     payloadFields.Actions,

--- a/pkg/services/opsgenie/opsgenie_config.go
+++ b/pkg/services/opsgenie/opsgenie_config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Priority    string            `key:"priority" desc:"Priority level of the alert. Possible values are P1, P2, P3, P4 and P5" optional:"true"`
 	Note        string            `key:"note" desc:"Additional note that will be added while creating the alert" optional:"true"`
 	User        string            `key:"user" desc:"Display name of the request owner" optional:"true"`
+	Title       string            `key:"title" default:"" desc:"notification title, optionally set by the sender"`
 }
 
 // Enums returns an empty map because the OpsGenie service doesn't use Enums

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -72,7 +72,7 @@ var _ = Describe("services", func() {
 				}
 
 				httpmock.Activate()
-				if key == "discord" {
+				if key == "discord" || key == "ifttt" {
 					// Always return a "No content" result, as the http request isn't what is under test
 					httpmock.RegisterNoResponder(httpmock.NewStringResponder(204, ""))
 				} else {

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -1,0 +1,100 @@
+package services_test
+
+import (
+	"github.com/containrrr/shoutrrr/pkg/router"
+	"github.com/containrrr/shoutrrr/pkg/services/gotify"
+	"github.com/containrrr/shoutrrr/pkg/types"
+	"github.com/jarcoal/httpmock"
+	"log"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestServices(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Service Compliance Suite")
+}
+
+var serviceURLs = map[string]string{
+	"discord":    "discord://token@id",
+	"gotify":     "gotify://example.com/Aaa.bbb.ccc.ddd",
+	"hangouts":   "hangouts://chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz",
+	"ifttt":      "ifttt://key?events=event",
+	"join":       "join://:apikey@join/?devices=device",
+	"logger":     "logger://",
+	"mattermost": "mattermost://user@example.com/token",
+	"opsgenie":   "opsgenie://example.com/token?responders=user:dummy",
+	"pushbullet": "pushbullet://tokentokentokentokentokentokentoke",
+	"pushover":   "pushover://:token@user/?devices=device",
+	"rocketchat": "rocketchat://example.com/token/channel",
+	"slack":      "slack://AAAAAAAAA/BBBBBBBBB/123456789123456789123456",
+	"smtp":       "smtp://host.tld:25/?fromAddress=from@host.tld&toAddresses=to@host.tld",
+	"teams":      "teams://11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/33333333012222222222333333333344/44444444-4444-4444-8444-cccccccccccc",
+	"telegram":   "telegram://000000000:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@telegram?channels=channel",
+	"xmpp":       "xmpp://",
+	"zulip":      "zulip://mail:key@example.com/?stream=foo&topic=bar",
+}
+
+var logger = log.New(GinkgoWriter, "Test", log.LstdFlags)
+
+var _ = Describe("services", func() {
+
+	BeforeEach(func() {
+
+	})
+	AfterEach(func() {
+
+	})
+
+	When("passed the a title param", func() {
+
+		var serviceRouter *router.ServiceRouter
+
+		AfterEach(func() {
+			httpmock.DeactivateAndReset()
+		})
+
+		for key, configURL := range serviceURLs {
+
+			key := key //necessary to ensure the correct value is passed to the closure
+			configURL := configURL
+			serviceRouter, _ = router.New(logger)
+
+			It("should not throw an error for "+key, func() {
+
+				if key == "smtp" {
+					Skip("smtp does not use HTTP and needs a specific test")
+				}
+				if key == "xmpp" {
+					Skip("not supported")
+				}
+
+				httpmock.Activate()
+				if key == "discord" {
+					// Always return a "No content" result, as the http request isn't what is under test
+					httpmock.RegisterNoResponder(httpmock.NewStringResponder(204, ""))
+				} else {
+					// Always return an "OK" result, as the http request isn't what is under test
+					httpmock.RegisterNoResponder(httpmock.NewStringResponder(200, ""))
+				}
+
+				service, err := serviceRouter.Locate(configURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				if key == "gotify" {
+					gotifyService := service.(*gotify.Service)
+					httpmock.ActivateNonDefault(gotifyService.Client)
+				}
+
+				err = service.Send("test", (*types.Params)(&map[string]string{
+					"title": "test title",
+				}))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+		}
+	})
+
+})

--- a/pkg/services/telegram/telegram_config.go
+++ b/pkg/services/telegram/telegram_config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Notification bool      `key:"notification" default:"Yes" desc:"If disabled, sends message silently"`
 	ParseMode    parseMode `key:"parsemode" default:"None" desc:"How the text message should be parsed"`
 	Channels     []string  `key:"channels"`
+	Title        string    `key:"title" default:"" desc:"notification title, optionally set by the sender"`
 }
 
 // Enums returns the fields that should use a corresponding EnumFormatter to Print/Parse their values

--- a/pkg/services/telegram/telegram_test.go
+++ b/pkg/services/telegram/telegram_test.go
@@ -151,7 +151,7 @@ var _ = Describe("the telegram service", func() {
 		testutils.TestConfigSetInvalidQueryValue(&Config{}, "telegram://12345:mock-token@telegram/?channels=channel-1&foo=bar")
 
 		testutils.TestConfigGetEnumsCount(&Config{}, 1)
-		testutils.TestConfigGetFieldsCount(&Config{}, 4)
+		testutils.TestConfigGetFieldsCount(&Config{}, 5)
 	})
 })
 


### PR DESCRIPTION
~~Note: This intentionally includes tests that currently fail.~~

Service Compliance information moved to [wiki page](https://github.com/containrrr/shoutrrr/wiki/Service-compliance).

The general point of this PR is to add tests to make sure that all services comply with the first Service Compliance rule:
> Services should not fail to send messages when the title param is passed. The service does not need to use it in any specific way, but it should not return an error (unless failing for some other reason).

Added test resulted in the following services that did not pass:
- **Telegram**  
   Supports Params? ✔ Yes!
   Supports Title prop?  ⚫ No
   Silently ignores title? ❌ Error: `title is not a valid config key [channels notification parsemode preview]`

- IFTT
   Supports Params? ✔ Yes!
   Uses title prop?  ⚫ No
   Silently ignores title? ❌Error `"title is not a valid config key [events messagevalue value1 value2 value3]"`

- OpsGenie
   Supports Params? ✔ Yes!
   Uses title prop?  ⚫ No
   Silently ignores title? ❌ Error: `title is not a valid config key [actions alias description details entity note priority responders source tags user visibleto]`

Fixes for the above services were added, and all three now pass. IFTT and OpsGenie can actually make use of the title as well if configured, but Telegram just ignores it.