### PR TITLE
fix(api): logging via interface and set/update using api

### DIFF
--- a/pkg/services/discord/discord.go
+++ b/pkg/services/discord/discord.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	"github.com/containrrr/shoutrrr/pkg/types"
 	"github.com/containrrr/shoutrrr/pkg/util"
-	"log"
 	"net/http"
 	"net/url"
 )
@@ -85,7 +84,7 @@ func CreateItemsFromPlain(plain string, splitLines bool) (items []types.MessageI
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	service.pkr = format.NewPropKeyResolver(service.config)

--- a/pkg/services/gotify/gotify.go
+++ b/pkg/services/gotify/gotify.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -25,7 +24,7 @@ type Service struct {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{
 		Title: "Shoutrrr notification",

--- a/pkg/services/hangouts/hangouts.go
+++ b/pkg/services/hangouts/hangouts.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -19,7 +18,7 @@ type Service struct {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service.
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 

--- a/pkg/services/ifttt/ifttt.go
+++ b/pkg/services/ifttt/ifttt.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/containrrr/shoutrrr/pkg/format"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -24,7 +23,7 @@ type Service struct {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{
 		UseMessageAsValue: 2,

--- a/pkg/services/join/join.go
+++ b/pkg/services/join/join.go
@@ -3,7 +3,6 @@ package join
 import (
 	"fmt"
 	"github.com/containrrr/shoutrrr/pkg/format"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -86,7 +85,7 @@ func (service *Service) sendToDevices(devices string, message string, title stri
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	service.pkr = format.NewPropKeyResolver(service.config)

--- a/pkg/services/logger/logger.go
+++ b/pkg/services/logger/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"fmt"
-	"log"
 	"net/url"
 	"strings"
 
@@ -39,7 +38,7 @@ func (service *Service) doSend(params *types.Params) error {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(_ *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(_ *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	return nil

--- a/pkg/services/mattermost/mattermost.go
+++ b/pkg/services/mattermost/mattermost.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -18,7 +17,7 @@ type Service struct {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	if err := service.config.SetURL(configURL); err != nil {

--- a/pkg/services/opsgenie/opsgenie.go
+++ b/pkg/services/opsgenie/opsgenie.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -57,7 +56,7 @@ func (service *Service) sendAlert(url string, apiKey string, payload AlertPayloa
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	service.pkr = format.NewPropKeyResolver(service.config)

--- a/pkg/services/pushbullet/pushbullet.go
+++ b/pkg/services/pushbullet/pushbullet.go
@@ -3,7 +3,6 @@ package pushbullet
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -19,7 +18,7 @@ type Service struct {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	if err := service.config.SetURL(configURL); err != nil {

--- a/pkg/services/pushover/pushover.go
+++ b/pkg/services/pushover/pushover.go
@@ -3,7 +3,6 @@ package pushover
 import (
 	"fmt"
 	"github.com/containrrr/shoutrrr/pkg/format"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -73,7 +72,7 @@ func (service *Service) sendToDevice(device string, message string, config *Conf
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	service.pkr = format.NewPropKeyResolver(service.config)

--- a/pkg/services/rocketchat/rocketchat.go
+++ b/pkg/services/rocketchat/rocketchat.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -19,7 +18,7 @@ type Service struct {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	if err := service.config.SetURL(configURL); err != nil {

--- a/pkg/services/slack/slack.go
+++ b/pkg/services/slack/slack.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/containrrr/shoutrrr/pkg/format"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -40,7 +39,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	service.pkr = format.NewPropKeyResolver(service.config)

--- a/pkg/services/smtp/smtp.go
+++ b/pkg/services/smtp/smtp.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"io"
-	"log"
 	"math/rand"
 	"net"
 	"net/smtp"
@@ -32,7 +31,7 @@ const (
 )
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{
 		Port:        25,

--- a/pkg/services/standard/standard_logger.go
+++ b/pkg/services/standard/standard_logger.go
@@ -1,14 +1,13 @@
 package standard
 
 import (
-	"log"
-
+	"github.com/containrrr/shoutrrr/pkg/types"
 	"github.com/containrrr/shoutrrr/pkg/util"
 )
 
 // Logger provides the utility methods Log* that maps to Logger.Print*
 type Logger struct {
-	logger *log.Logger
+	logger types.StdLogger
 }
 
 // Logf maps to the service loggers Logger.Printf function
@@ -22,7 +21,7 @@ func (sl *Logger) Log(v ...interface{}) {
 }
 
 // SetLogger maps the specified logger to the Log* helper methods
-func (sl *Logger) SetLogger(logger *log.Logger) {
+func (sl *Logger) SetLogger(logger types.StdLogger) {
 	if logger == nil {
 		sl.logger = util.DiscardLogger
 	} else {

--- a/pkg/services/teams/teams.go
+++ b/pkg/services/teams/teams.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/containrrr/shoutrrr/pkg/format"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -33,7 +32,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{
 		Host: DefaultHost,

--- a/pkg/services/telegram/telegram.go
+++ b/pkg/services/telegram/telegram.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/containrrr/shoutrrr/pkg/format"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -41,7 +40,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{
 		Preview:      true,

--- a/pkg/services/xmpp/xmpp.go
+++ b/pkg/services/xmpp/xmpp.go
@@ -1,7 +1,6 @@
 package xmpp
 
 import (
-	"log"
 	"net/url"
 
 	"gosrc.io/xmpp"
@@ -22,7 +21,7 @@ type Service struct {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{
 		Port:    5222,

--- a/pkg/services/zulip/zulip.go
+++ b/pkg/services/zulip/zulip.go
@@ -2,7 +2,6 @@ package zulip
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -55,7 +54,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
-func (service *Service) Initialize(configURL *url.URL, logger *log.Logger) error {
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 

--- a/pkg/types/service.go
+++ b/pkg/types/service.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"log"
 	"net/url"
 )
 
@@ -9,5 +8,6 @@ import (
 type Service interface {
 	Sender
 	Templater
-	Initialize(serviceURL *url.URL, logger *log.Logger) error
+	Initialize(serviceURL *url.URL, logger StdLogger) error
+	SetLogger(logger StdLogger)
 }

--- a/pkg/types/std_logger.go
+++ b/pkg/types/std_logger.go
@@ -1,0 +1,9 @@
+package types
+
+// StdLogger is an interface of a subset of the stdlib log.Logger used for
+// outputting log information from services that are non-fatal
+type StdLogger interface {
+	Print(...interface{})
+	Printf(string, ...interface{})
+	Println(...interface{})
+}

--- a/shoutrrr.go
+++ b/shoutrrr.go
@@ -3,14 +3,12 @@ package shoutrrr
 import (
 	"github.com/containrrr/shoutrrr/pkg/router"
 	"github.com/containrrr/shoutrrr/pkg/types"
-
-	"log"
 )
 
 var defaultRouter = router.ServiceRouter{}
 
 // SetLogger sets the logger that the services will use to write progress logs
-func SetLogger(logger *log.Logger) {
+func SetLogger(logger types.StdLogger) {
 	defaultRouter.SetLogger(logger)
 }
 
@@ -27,4 +25,10 @@ func Send(rawURL string, message string) error {
 // CreateSender returns a notification sender configured according to the supplied URL
 func CreateSender(rawURLs ...string) (*router.ServiceRouter, error) {
 	return router.New(nil, rawURLs...)
+}
+
+// NewSender returns a notification sender, writing any log output to logger and configured
+// to send to the services indicated by the supplied URLs
+func NewSender(logger types.StdLogger, serviceURLs ...string) (*router.ServiceRouter, error) {
+	return router.New(logger, serviceURLs...)
 }


### PR DESCRIPTION
Previously the public api only contained a constructor that did not set up logging, and even worse, adding logging after calling `shoutrrr.CreateSender` only applied said logging to any subsequently added services. Which of course there were no API to do either.
So, a new public API constructor was added using the name `NewSender` that takes a logger as it's first argument (can be nil), and also moves the adding/initializing of services to a separate method that can be called after init.

This also replaces the stdlib `log.Logger` with an interface that can be implemented by other logging providers.