### PR TITLE
Use absolute path for entrypoint in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY --from=alpine \
     /etc/ssl/certs/ca-certificates.crt
 COPY shoutrrr /
 
-ENTRYPOINT ["./shoutrrr"]
+ENTRYPOINT ["/shoutrrr"]


### PR DESCRIPTION
If the entrypoint uses a relative path we are not able to set a different working directory, i.e. in Dockerfiles extending this.
