### PR TITLE
fix: discord avatar override

### DIFF
--- a/pkg/services/discord/discord.go
+++ b/pkg/services/discord/discord.go
@@ -63,6 +63,7 @@ func (service *Service) sendItems(items []types.MessageItem, params *types.Param
 	}
 
 	payload.Username = config.Username
+	payload.AvatarURL = config.Avatar
 
 	var payloadBytes []byte
 	payloadBytes, err = json.Marshal(payload)

--- a/pkg/services/discord/discord_config.go
+++ b/pkg/services/discord/discord_config.go
@@ -15,7 +15,7 @@ type Config struct {
 	Token      string `url:"user"`
 	Title      string `key:"title"      default:""`
 	Username   string `key:"username"   default:""         desc:"Override the webhook default username"`
-	AvatarURL  string `key:"avatar"     default:""         desc:"Override the webhook default avatar"`
+	Avatar     string `key:"avatar,avatarurl"     default:""         desc:"Override the webhook default avatar with specified URL"`
 	Color      uint   `key:"color"      default:"0x50D9ff" desc:"The color of the left border for plain messages"   base:"16"`
 	ColorError uint   `key:"colorError" default:"0xd60510" desc:"The color of the left border for error messages"   base:"16"`
 	ColorWarn  uint   `key:"colorWarn"  default:"0xffc441" desc:"The color of the left border for warning messages" base:"16"`

--- a/pkg/services/discord/discord_json.go
+++ b/pkg/services/discord/discord_json.go
@@ -11,6 +11,7 @@ import (
 type WebhookPayload struct {
 	Embeds   []embedItem `json:"embeds"`
 	Username string      `json:"username,omitempty"`
+	AvatarURL string     `json:"avatar_url,omitempty"`
 }
 
 // JSON is the actual notification payload


### PR DESCRIPTION
Fixes Discord avatar override not being populated in the webhook payload. Also, this fixes the documentation name of the prop (and adds an alias for `avatarurl` which was listed in the docs previosuly).