### PR TITLE
Slack: add properties for overriding channel and emoji

### DIFF
--- a/docs/services/slack.md
+++ b/docs/services/slack.md
@@ -19,15 +19,16 @@ Shoutrrr URL:
     
 --8<-- "docs/services/slack/config.md"
 
-!!! info "Color format"
+!!! info "Some properties require URL encoding"
     The format for the `Color` prop follows the [slack docs](https://api.slack.com/reference/messaging/attachments#fields)
     but `#` needs to be escaped as `%23` when passed in a URL.  
     So <span style="background:#ff8000;width:.9em;height:.9em;display:inline-block;vertical-align:middle"></span><code>#ff8000</code> would be `%23ff8000` etc.
-
+    
+    The same applies to the `Channel` property when prefixing with `#` (not required).
 ## Examples
 
 !!! example
     All fields set:
     ```uri
-    slack://ShoutrrrBot@T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX?color=good&title=Great+News
+    slack://ShoutrrrBot@T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX?channel=non-default-chan&color=good&emoji=sunny&title=Great+News
     ```

--- a/pkg/services/slack/slack_config.go
+++ b/pkg/services/slack/slack_config.go
@@ -16,6 +16,8 @@ type Config struct {
 	Token   []string `desc:"Webhook token parts" url:"host,path1,path2"`
 	Color   string   `key:"color" optional:"" desc:"Message left-hand border color"`
 	Title   string   `key:"title" optional:"" desc:"Prepended text above the message"`
+	Channel string   `key:"channel" optional:"" desc:"Overridden channel name (e.g. shoutrrr) or ID (e.g. C8UJ12P4P)"`
+	Emoji   string   `key:"emoji" optional:"" desc:"Overridden emoji name (with or without colons) from the Slack workspace"`
 }
 
 // GetURL returns a URL representation of it's current field values

--- a/pkg/services/slack/slack_errors.go
+++ b/pkg/services/slack/slack_errors.go
@@ -10,11 +10,11 @@ const (
 	TokenBMissing ErrorMessage = "second part of the API token is missing"
 	// TokenCMissing from the service URL
 	TokenCMissing ErrorMessage = "third part of the API token is missing."
-	// TokenAMalformed inthe service URL
+	// TokenAMalformed in the service URL
 	TokenAMalformed ErrorMessage = "first part of the API token is malformed"
-	// TokenBMalformed inthe service URL
+	// TokenBMalformed in the service URL
 	TokenBMalformed ErrorMessage = "second part of the API token is malformed"
-	// TokenCMalformed inthe service URL
+	// TokenCMalformed in the service URL
 	TokenCMalformed ErrorMessage = "third part of the API token is malformed"
 	// NotEnoughArguments provided in the service URL
 	NotEnoughArguments ErrorMessage = "the apiURL does not include enough arguments"

--- a/pkg/services/slack/slack_json.go
+++ b/pkg/services/slack/slack_json.go
@@ -9,6 +9,8 @@ import (
 type JSON struct {
 	Text        string       `json:"text"`
 	BotName     string       `json:"username,omitempty"`
+	Channel     string       `json:"channel,omitempty"`
+	Emoji       string       `json:"icon_emoji,omitempty"`
 	Blocks      []block      `json:"blocks,omitempty"`
 	Attachments []attachment `json:"attachments,omitempty"`
 }
@@ -54,6 +56,8 @@ func CreateJSONPayload(config *Config, message string) ([]byte, error) {
 		JSON{
 			Text:        config.Title,
 			BotName:     config.BotName,
+			Channel:     config.Channel,
+			Emoji:       config.Emoji,
 			Attachments: atts,
 		})
 }

--- a/pkg/services/slack/slack_test.go
+++ b/pkg/services/slack/slack_test.go
@@ -105,7 +105,7 @@ var _ = Describe("the slack service", func() {
 	Describe("the slack config", func() {
 		When("parsing the configuration URL", func() {
 			It("should be identical after de-/serialization", func() {
-				testURL := "slack://testbot@AAAAAAAAA/BBBBBBBBB/123456789123456789123456?color=3f00fe&title=Test+title"
+				testURL := "slack://testbot@AAAAAAAAA/BBBBBBBBB/123456789123456789123456?channel=foo&color=3f00fe&emoji=sunny&title=Test+title"
 
 				url, err := url.Parse(testURL)
 				Expect(err).NotTo(HaveOccurred(), "parsing")


### PR DESCRIPTION
After looking into the new kured 1.7.0 release, I came across a couple of properties that I miss after the transition to shoutrrr. This PR introduces two new properties in the Slack service:

- *channel:* allows for overriding which channel to be notified (default is using the channel specifying in the Slack webhook configuration)
- *emoji:* use a custom icon for the messages posted by shoutrrr

Related to #88, https://github.com/weaveworks/kured/pull/368