### PR TITLE
feat(slack): add thread/reply support

### DIFF
--- a/pkg/services/slack/slack_config.go
+++ b/pkg/services/slack/slack_config.go
@@ -2,20 +2,22 @@ package slack
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	"github.com/containrrr/shoutrrr/pkg/types"
-	"net/url"
-	"strings"
 )
 
 // Config for the slack service
 type Config struct {
 	standard.EnumlessConfig
-	BotName string   `default:"" optional:"" url:"user" desc:"Bot name (uses default if empty)"`
-	Token   []string `desc:"Webhook token parts" url:"host,path1,path2"`
-	Color   string   `key:"color" optional:"" desc:"Message left-hand border color"`
-	Title   string   `key:"title" optional:"" desc:"Prepended text above the message"`
+	BotName  string   `default:"" optional:"" url:"user" desc:"Bot name (uses default if empty)"`
+	Token    []string `desc:"Webhook token parts" url:"host,path1,path2"`
+	Color    string   `key:"color" optional:"" desc:"Message left-hand border color"`
+	Title    string   `key:"title" optional:"" desc:"Prepended text above the message"`
+	ThreadTS string   `key:"thread_ts" optional:"" desc:"ts value of the parent message (to send message as reply in thread)"`
 }
 
 // GetURL returns a URL representation of it's current field values

--- a/pkg/services/slack/slack_json.go
+++ b/pkg/services/slack/slack_json.go
@@ -11,6 +11,7 @@ type JSON struct {
 	BotName     string       `json:"username,omitempty"`
 	Blocks      []block      `json:"blocks,omitempty"`
 	Attachments []attachment `json:"attachments,omitempty"`
+	ThreadTS    string       `json:"thread_ts,omitempty"`
 }
 
 type block struct {
@@ -52,6 +53,7 @@ func CreateJSONPayload(config *Config, message string) ([]byte, error) {
 
 	return json.Marshal(
 		JSON{
+			ThreadTS:    config.ThreadTS,
 			Text:        config.Title,
 			BotName:     config.BotName,
 			Attachments: atts,


### PR DESCRIPTION
- Added `thread_ts` field to Config and JSON 
- If thread  time stamp is supplied it will be sent as reply to message in a thread
- Reference https://api.slack.com/messaging/webhooks#threads