### PR TITLE
fix(logger): avoid mutating passed params

### DIFF
--- a/pkg/services/logger/logger.go
+++ b/pkg/services/logger/logger.go
@@ -17,18 +17,21 @@ type Service struct {
 
 // Send a notification message to log
 func (service *Service) Send(message string, params *types.Params) error {
-	if params == nil {
-		params = &types.Params{}
+	data := types.Params{}
+	if params != nil {
+		for key, value := range *params {
+			data[key] = value
+		}
 	}
-	(*params)["message"] = message
-	return service.doSend(params)
+	data["message"] = message
+	return service.doSend(data)
 }
 
-func (service *Service) doSend(params *types.Params) error {
-	msg := (*params)["message"]
+func (service *Service) doSend(data types.Params) error {
+	msg := data["message"]
 	if tpl, found := service.GetTemplate("message"); found {
 		wc := &strings.Builder{}
-		if err := tpl.Execute(wc, params); err != nil {
+		if err := tpl.Execute(wc, data); err != nil {
 			return fmt.Errorf("failed to write template to log: %s", err)
 		}
 		msg = wc.String()

--- a/pkg/services/logger/logger_suite_test.go
+++ b/pkg/services/logger/logger_suite_test.go
@@ -1,0 +1,65 @@
+package logger_test
+
+import (
+	unit "github.com/containrrr/shoutrrr/pkg/services/logger"
+	"github.com/containrrr/shoutrrr/pkg/types"
+
+	"github.com/containrrr/shoutrrr/pkg/util"
+	"github.com/onsi/gomega/gbytes"
+
+	"log"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogger(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logger Suite")
+}
+
+var _ = Describe("the logger service", func() {
+
+	When("sending a notification", func() {
+
+		It("should output the message to the log", func() {
+			logbuf := gbytes.NewBuffer()
+			service := &unit.Service{}
+			_ = service.Initialize(util.URLMust(`logger://`), log.New(logbuf, "", 0))
+
+			err := service.Send(`Failed - Requires Toaster Repair Level 10`, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(logbuf).Should(gbytes.Say("Failed - Requires Toaster Repair Level 10"))
+		})
+
+		It("should not mutate the passed params", func() {
+			service := &unit.Service{}
+			_ = service.Initialize(util.URLMust(`logger://`), nil)
+			params := types.Params{}
+			err := service.Send(`Failed - Requires Toaster Repair Level 10`, &params)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(params).To(BeEmpty())
+		})
+
+		When("when a template has been added", func() {
+			It("should render template with params", func() {
+				logbuf := gbytes.NewBuffer()
+				service := &unit.Service{}
+				_ = service.Initialize(util.URLMust(`logger://`), log.New(logbuf, "", 0))
+				err := service.SetTemplateString(`message`, `{{.level}}: {{.message}}`)
+				Expect(err).NotTo(HaveOccurred())
+
+				params := types.Params{
+					"level": "warning",
+				}
+				err = service.Send(`Requires Toaster Repair Level 10`, &params)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(logbuf).Should(gbytes.Say("warning: Requires Toaster Repair Level 10"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
this fixes an old bug where the logger, when combined with other services would add the param `message` to other services `Send()` (which they usually don't like).

also added tests for this and for normal operation.