### PR TITLE
fix(teams): use correct path in webhook URL

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -6,14 +6,16 @@ import (
 	"github.com/containrrr/shoutrrr/cli/cmd/generate"
 	"github.com/containrrr/shoutrrr/cli/cmd/send"
 	"github.com/containrrr/shoutrrr/cli/cmd/verify"
+	"github.com/containrrr/shoutrrr/internal/meta"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
 )
 
 var cmd = &cobra.Command{
-	Use:   "shoutrrr",
-	Short: "Notification library for gophers and their furry friends",
+	Use:     "shoutrrr",
+	Version: meta.Version,
+	Short:   "Shoutrrr CLI",
 }
 
 func init() {

--- a/internal/meta/version.go
+++ b/internal/meta/version.go
@@ -1,0 +1,7 @@
+package meta
+
+// Version of Shoutrrr
+const Version = `0.5-dev`
+
+// DocsVersion is prepended to documentation URLs and usually equals MAJOR.MINOR of Version
+const DocsVersion = `dev`

--- a/pkg/services/teams/teams_config.go
+++ b/pkg/services/teams/teams_config.go
@@ -114,14 +114,21 @@ func (config *Config) setFromWebhookParts(parts [4]string) {
 	config.GroupOwner = parts[3]
 }
 
-func buildWebhookURL(host string, parts [4]string) string {
+func buildWebhookURL(host, group, tenant, altID, groupOwner string) string {
+	// config.Group, config.Tenant, config.AltID, config.GroupOwner
+	path := Path
+	if host == LegacyHost {
+		path = LegacyPath
+	}
 	return fmt.Sprintf(
-		"https://%s/webhook/%s@%s/IncomingWebhook/%s/%s",
+		"https://%s/%s/%s@%s/%s/%s/%s",
 		host,
-		parts[0],
-		parts[1],
-		parts[2],
-		parts[3])
+		path,
+		group,
+		tenant,
+		ProviderName,
+		altID,
+		groupOwner)
 }
 
 func parseAndVerifyWebhookURL(webhookURL string) (parts [4]string, err error) {
@@ -142,6 +149,12 @@ func parseAndVerifyWebhookURL(webhookURL string) (parts [4]string, err error) {
 const (
 	// Scheme is the identifying part of this service's configuration URL
 	Scheme = "teams"
-	// DefaultHost is the default host for the webhook request
-	DefaultHost = "outlook.office.com"
+	// LegacyHost is the default host for legacy webhook requests
+	LegacyHost = "outlook.office.com"
+	// LegacyPath is the initial path of the webhook URL for legacy webhook requests
+	LegacyPath = "webhook"
+	// Path is the initial path of the webhook URL for domain-scoped webhook requests
+	Path = "webhookb2"
+	// ProviderName is the name of the Teams integration provider
+	ProviderName = "IncomingWebhook"
 )

--- a/pkg/util/docs.go
+++ b/pkg/util/docs.go
@@ -6,6 +6,12 @@ import (
 	"github.com/containrrr/shoutrrr/internal/meta"
 )
 
+// DocsURL returns a full documentation URL for the current version of Shoutrrr with the path appended.
+// If the path contains a leading slash, it is stripped.
 func DocsURL(path string) string {
+	// strip leading slash if present
+	if len(path) > 0 && path[0] == '/' {
+		path = path[1:]
+	}
 	return fmt.Sprintf("https://containrrr.dev/shoutrrr/%s/%s", meta.DocsVersion, path)
 }

--- a/pkg/util/docs.go
+++ b/pkg/util/docs.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/containrrr/shoutrrr/internal/meta"
+)
+
+func DocsURL(path string) string {
+	return fmt.Sprintf("https://containrrr.dev/shoutrrr/%s/%s", meta.DocsVersion, path)
+}

--- a/pkg/util/partition_message_test.go
+++ b/pkg/util/partition_message_test.go
@@ -118,13 +118,9 @@ func testPartitionMessage(hundreds int, limits types.MessageLimit, distance int)
 
 	items, omitted = PartitionMessage(builder.String(), limits, distance)
 
-	println(hundreds, len(items), omitted)
-
 	contentSize := Min(hundreds*100, limits.TotalChunkSize)
 	expectedChunkCount := CeilDiv(contentSize, limits.ChunkSize-1)
 	expectedOmitted := Max(0, (hundreds*100)-contentSize)
-
-	println(contentSize, expectedChunkCount, expectedOmitted)
 
 	Expect(omitted).To(Equal(expectedOmitted))
 	Expect(len(items)).To(Equal(expectedChunkCount))

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,12 +1,14 @@
 package util_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/containrrr/shoutrrr/internal/meta"
 	. "github.com/containrrr/shoutrrr/pkg/util"
 )
 
@@ -89,6 +91,17 @@ var _ = Describe("the util package", func() {
 		})
 		It("should be false if supplied a constant string", func() {
 			Expect(IsNumeric(reflect.TypeOf("3").Kind())).To(BeFalse())
+		})
+	})
+
+	When("calling function DocsURL", func() {
+		It("should return the expected URL", func() {
+			expectedBase := fmt.Sprintf(`https://containrrr.dev/shoutrrr/%s/`, meta.DocsVersion)
+			Expect(DocsURL(``)).To(Equal(expectedBase))
+			Expect(DocsURL(`services/logger`)).To(Equal(expectedBase + `services/logger`))
+		})
+		It("should strip the leading slash from the path", func() {
+			Expect(DocsURL(`/foo`)).To(Equal(DocsURL(`foo`)))
 		})
 	})
 })

--- a/shoutrrr.go
+++ b/shoutrrr.go
@@ -1,6 +1,7 @@
 package shoutrrr
 
 import (
+	"github.com/containrrr/shoutrrr/internal/meta"
 	"github.com/containrrr/shoutrrr/pkg/router"
 	"github.com/containrrr/shoutrrr/pkg/types"
 )
@@ -31,4 +32,9 @@ func CreateSender(rawURLs ...string) (*router.ServiceRouter, error) {
 // to send to the services indicated by the supplied URLs
 func NewSender(logger types.StdLogger, serviceURLs ...string) (*router.ServiceRouter, error) {
 	return router.New(logger, serviceURLs...)
+}
+
+// Version returns the shoutrrr version
+func Version() string {
+	return meta.Version
 }


### PR DESCRIPTION
fixes #187 

also includes static versioning information to allow linking docs in log messages