### PR TITLE
fix(router): check for nil logger

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -186,7 +186,7 @@ func (router *ServiceRouter) initService(rawURL string) (t.Service, error) {
 	}
 
 	if configURL.Scheme != scheme {
-		router.logger.Println("Got custom URL:", configURL.String())
+		router.log("Got custom URL:", configURL.String())
 		customURLService, ok := service.(t.CustomURLService)
 		if !ok {
 			return nil, fmt.Errorf("custom URLs are not supported by '%s' service", scheme)
@@ -195,7 +195,7 @@ func (router *ServiceRouter) initService(rawURL string) (t.Service, error) {
 		if err != nil {
 			return nil, err
 		}
-		router.logger.Println("Converted service URL:", configURL.String())
+		router.log("Converted service URL:", configURL.String())
 	}
 
 	err = service.Initialize(configURL, router.logger)
@@ -237,4 +237,11 @@ func (router *ServiceRouter) ListServices() []string {
 func (router *ServiceRouter) Locate(rawURL string) (t.Service, error) {
 	service, err := router.initService(rawURL)
 	return service, err
+}
+
+func (router *ServiceRouter) log(v ...interface{}) {
+	if router.logger == nil {
+		return
+	}
+	router.logger.Println(v...)
 }

--- a/pkg/router/router_suite_test.go
+++ b/pkg/router/router_suite_test.go
@@ -17,6 +17,10 @@ func TestRouter(t *testing.T) {
 
 var sr ServiceRouter
 
+const (
+	mockCustomURL = "teams+https://publicservice.info/webhook/11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/IncomingWebhook/33333333012222222222333333333344/44444444-4444-4444-8444-cccccccccccc"
+)
+
 var _ = Describe("the router suite", func() {
 	BeforeEach(func() {
 		sr = ServiceRouter{
@@ -84,7 +88,7 @@ var _ = Describe("the router suite", func() {
 			Expect(service).To(BeNil())
 		})
 		It("should successfully init a service that does support it", func() {
-			service, err := sr.initService("teams+https://publicservice.info/webhook/11111111-4444-4444-8444-cccccccccccc@22222222-4444-4444-8444-cccccccccccc/IncomingWebhook/33333333012222222222333333333344/44444444-4444-4444-8444-cccccccccccc")
+			service, err := sr.initService(mockCustomURL)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(service).NotTo(BeNil())
 		})
@@ -111,6 +115,13 @@ var _ = Describe("the router suite", func() {
 				defer sr.Flush(nil)
 				sr.Enqueue("message")
 			})
+		})
+	})
+	When("router has not been provided a logger", func() {
+		It("should not crash when trying to log", func() {
+			router := ServiceRouter{}
+			_, err := router.initService(mockCustomURL)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
use a safe logging wrapper to avoid dereferencing a nil logger inside the router

fixes #186 