### PR TITLE
add general basic tests for services

### DIFF
--- a/generate-service-config-docs.sh
+++ b/generate-service-config-docs.sh
@@ -20,7 +20,7 @@ fi
 
 for S in ./pkg/services/*; do
   SERVICE=$(basename "$S")
-  if [[ "$SERVICE" == "standard" ]] || [[ -f "$S" ]]; then
+  if [[ "$SERVICE" == "standard" ]] || [[ "$SERVICE" == "xmpp" ]]  || [[ -f "$S" ]]; then
     continue
   fi
   generate_docs "$SERVICE"

--- a/pkg/router/servicemap.go
+++ b/pkg/router/servicemap.go
@@ -18,14 +18,13 @@ import (
 	"github.com/containrrr/shoutrrr/pkg/services/smtp"
 	"github.com/containrrr/shoutrrr/pkg/services/teams"
 	"github.com/containrrr/shoutrrr/pkg/services/telegram"
-	"github.com/containrrr/shoutrrr/pkg/services/xmpp"
 	"github.com/containrrr/shoutrrr/pkg/services/zulip"
 	t "github.com/containrrr/shoutrrr/pkg/types"
 )
 
 var serviceMap = map[string]func() t.Service{
 	"discord":    func() t.Service { return &discord.Service{} },
-  "generic":    func() t.Service { return &generic.Service{} },
+	"generic":    func() t.Service { return &generic.Service{} },
 	"gotify":     func() t.Service { return &gotify.Service{} },
 	"googlechat": func() t.Service { return &googlechat.Service{} },
 	"hangouts":   func() t.Service { return &googlechat.Service{} },
@@ -42,6 +41,5 @@ var serviceMap = map[string]func() t.Service{
 	"smtp":       func() t.Service { return &smtp.Service{} },
 	"teams":      func() t.Service { return &teams.Service{} },
 	"telegram":   func() t.Service { return &telegram.Service{} },
-	"xmpp":       func() t.Service { return &xmpp.Service{} },
 	"zulip":      func() t.Service { return &zulip.Service{} },
 }

--- a/pkg/router/servicemap_xmpp.go
+++ b/pkg/router/servicemap_xmpp.go
@@ -1,0 +1,7 @@
+//+build xmpp
+
+package router
+
+func init() {
+	serviceMap["xmpp"] = func() t.Service { return &xmpp.Service{} }
+}

--- a/pkg/services/googlechat/googlechat_test.go
+++ b/pkg/services/googlechat/googlechat_test.go
@@ -1,6 +1,7 @@
 package googlechat
 
 import (
+	"github.com/jarcoal/httpmock"
 	"net/url"
 	"testing"
 
@@ -13,14 +14,59 @@ func TestGooglechat(t *testing.T) {
 	RunSpecs(t, "Shoutrrr Google Chat Suite")
 }
 
-var _ = Describe("the Googlechat Chat plugin URL building", func() {
+var _ = Describe("Google Chat Service", func() {
 	It("should build a valid Google Chat Incoming Webhook URL", func() {
 		configURL, _ := url.Parse("googlechat://chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz")
 
 		config := Config{}
-		config.SetURL(configURL)
+		Expect(config.SetURL(configURL)).To(Succeed())
 
 		expectedURL := "https://chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz"
 		Expect(getAPIURL(&config).String()).To(Equal(expectedURL))
+	})
+	When("parsing the configuration URL", func() {
+		It("should be identical after de-/serialization", func() {
+			testURL := "googlechat://chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz"
+
+			url, err := url.Parse(testURL)
+			Expect(err).NotTo(HaveOccurred(), "parsing")
+
+			config := &Config{}
+			err = config.SetURL(url)
+			Expect(err).NotTo(HaveOccurred(), "verifying")
+
+			outputURL := config.GetURL()
+
+			Expect(outputURL.String()).To(Equal(testURL))
+
+		})
+	})
+
+	Describe("sending the payload", func() {
+		var err error
+		BeforeEach(func() {
+			httpmock.Activate()
+		})
+		AfterEach(func() {
+			httpmock.DeactivateAndReset()
+		})
+		It("should not report an error if the server accepts the payload", func() {
+			config := Config{
+				Host:  "chat.googleapis.com",
+				Path:  "v1/spaces/FOO/messages",
+				Key:   "bar",
+				Token: "baz",
+			}
+			serviceURL := config.GetURL()
+			service := Service{}
+			err = service.Initialize(serviceURL, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			httpmock.RegisterResponder("POST", "https://chat.googleapis.com/v1/spaces/FOO/messages?key=bar&token=baz", httpmock.NewStringResponder(200, ``))
+
+			err = service.Send("Message", nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 	})
 })

--- a/pkg/services/mattermost/mattermost_config.go
+++ b/pkg/services/mattermost/mattermost_config.go
@@ -18,13 +18,18 @@ type Config struct {
 
 // GetURL returns a URL representation of it's current field values
 func (config *Config) GetURL() *url.URL {
-	path := config.Token
-	if config.Channel != "" {
-		path += "/" + config.Channel
+	paths := []string{"", config.Token, config.Channel}
+	if config.Channel == "" {
+		paths = paths[:2]
+	}
+	var user *url.Userinfo
+	if config.UserName != "" {
+		user = url.User(config.UserName)
 	}
 	return &url.URL{
+		User:       user,
 		Host:       config.Host,
-		Path:       path,
+		Path:       strings.Join(paths, "/"),
 		Scheme:     Scheme,
 		ForceQuery: false,
 	}

--- a/pkg/services/xmpp/xmpp.go
+++ b/pkg/services/xmpp/xmpp.go
@@ -1,3 +1,5 @@
+//+build xmpp
+
 package xmpp
 
 import (

--- a/pkg/services/xmpp/xmpp_config.go
+++ b/pkg/services/xmpp/xmpp_config.go
@@ -1,3 +1,5 @@
+//+build xmpp
+
 package xmpp
 
 import (

--- a/pkg/services/xmpp/xmpp_test.go
+++ b/pkg/services/xmpp/xmpp_test.go
@@ -1,3 +1,5 @@
+//+build xmpp
+
 package xmpp
 
 import (


### PR DESCRIPTION
this should bump up the test coverage a bit and fix some smaller serialization issues found while testing.

also, this disables the XMPP service (behind a build constraint) until it's deemed stable.