### PR TITLE
fix(docs): replace props desc when empty

### DIFF
--- a/cli/cmd/docs/docs.go
+++ b/cli/cmd/docs/docs.go
@@ -51,8 +51,9 @@ func printDocs(format string, services []string) cli.Result {
 		renderer = f.ConsoleTreeRenderer{WithValues: false}
 	case "markdown":
 		renderer = f.MarkdownTreeRenderer{
-			HeaderPrefix:     "### ",
-			PropsDescription: "Props can be either supplied using the params argument, or through the URL using  \n`?key=value&key=value` etc.\n",
+			HeaderPrefix:      "### ",
+			PropsDescription:  "Props can be either supplied using the params argument, or through the URL using  \n`?key=value&key=value` etc.\n",
+			PropsEmptyMessage: "*The services does not support any query/param props*",
 		}
 	default:
 		return cli.InvalidUsage("invalid format")

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Shoutrrr
 
 <div align="center">
-<img src="https://raw.githubusercontent.com/containrrr/shoutrrr/master/docs/shoutrrr-logotype.png" width="450" />
+<img src="https://raw.githubusercontent.com/containrrr/shoutrrr/main/docs/shoutrrr-logotype.png" height="450" width="450" />
 </div>
 
 <p align="center">
@@ -14,7 +14,7 @@ Heavily inspired by <a href="https://github.com/caronc/apprise">caronc/apprise</
         <img src="https://github.com/containrrr/shoutrrr/workflows/Main%20Workflow/badge.svg" alt="github actions workflow status">
     </a>
     <a href="https://codecov.io/gh/containrrr/shoutrrr" rel="nofollow">
-        <img alt="codecov" src="https://codecov.io/gh/containrrr/shoutrrr/branch/master/graph/badge.svg">
+        <img alt="codecov" src="https://codecov.io/gh/containrrr/shoutrrr/branch/main/graph/badge.svg">
     </a>
     <a href="https://www.codacy.com/gh/containrrr/shoutrrr/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=containrrr/shoutrrr&amp;utm_campaign=Badge_Grade" rel="nofollow">
         <img alt="Codacy Badge" src="https://app.codacy.com/project/badge/Grade/47eed72de79448e2a6e297d770355544">
@@ -28,7 +28,7 @@ Heavily inspired by <a href="https://github.com/caronc/apprise">caronc/apprise</
     <a href="https://github.com/containrrr/shoutrrr">
         <img alt="github code size in bytes" src="https://img.shields.io/github/languages/code-size/containrrr/shoutrrr.svg?style=flat-square">
     </a>
-    <a href="https://github.com/containrrr/shoutrrr/blob/master/LICENSE">
+    <a href="https://github.com/containrrr/shoutrrr/blob/main/LICENSE">
         <img alt="license" src="https://img.shields.io/github/license/containrrr/shoutrrr.svg?style=flat-square">
     </a>
 </p>
@@ -37,4 +37,4 @@ Heavily inspired by <a href="https://github.com/caronc/apprise">caronc/apprise</
 
 To make it easy and streamlined to consume shoutrrr regardless of the notification service you want to use,
 we've implemented a notification service url schema. To send notifications, instantiate the `ShoutrrrClient` using one of
-the service urls from the [overview](/shoutrrr/services/overview).
+the service urls from the [overview](services/overview.md).

--- a/pkg/format/render_markdown.go
+++ b/pkg/format/render_markdown.go
@@ -8,8 +8,9 @@ import (
 
 // MarkdownTreeRenderer renders a ContainerNode tree into a markdown documentation string
 type MarkdownTreeRenderer struct {
-	HeaderPrefix     string
-	PropsDescription string
+	HeaderPrefix      string
+	PropsDescription  string
+	PropsEmptyMessage string
 }
 
 // RenderTree renders a ContainerNode tree into a markdown documentation string
@@ -43,7 +44,11 @@ func (r MarkdownTreeRenderer) RenderTree(root *ContainerNode, scheme string) str
 	})
 
 	r.writeHeader(&sb, "Query/Param Props")
-	sb.WriteString(r.PropsDescription)
+	if len(queryFields) > 0 {
+		sb.WriteString(r.PropsDescription)
+	} else {
+		sb.WriteString(r.PropsEmptyMessage)
+	}
 	sb.WriteRune('\n')
 	for _, field := range queryFields {
 		r.writeFieldPrimary(&sb, field)

--- a/pkg/format/render_markdown_test.go
+++ b/pkg/format/render_markdown_test.go
@@ -91,8 +91,63 @@ var _ = Describe("RenderMarkdown", func() {
   Possible values: ` + "`Yes`, `No`, `Maybe`" + `  
 
 `
-		println()
-		println(actual)
+
 		Expect(actual).To(Equal(expected))
 	})
+
+	When("there are no query props", func() {
+		It("should prepend an empty-message instead of props description", func() {
+			actual := testRenderTree(MarkdownTreeRenderer{
+				HeaderPrefix:      `### `,
+				PropsDescription:  "Feel free to set these:",
+				PropsEmptyMessage: "There is nothing to set!",
+			}, &struct {
+				Host string `url:"host"`
+			}{})
+
+			expected := `
+### URL Fields
+
+*  __Host__ (**Required**)  
+  URL part: <code class="service-url">mock://<strong>host</strong>/</code>  
+### Query/Param Props
+
+There is nothing to set!
+`[1:] // Remove initial newline
+
+			//_ = actual == expected
+			//println()
+			//println(actual)
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	When("there are query props", func() {
+		It("should prepend the props description", func() {
+			actual := testRenderTree(MarkdownTreeRenderer{
+				HeaderPrefix:      `### `,
+				PropsDescription:  "Feel free to set these:",
+				PropsEmptyMessage: "There is nothing to set!",
+			}, &struct {
+				Host     string `url:"host"`
+				CoolMode bool   `key:"coolmode" optional:""`
+			}{})
+
+			expected := `
+### URL Fields
+
+*  __Host__ (**Required**)  
+  URL part: <code class="service-url">mock://<strong>host</strong>/</code>  
+### Query/Param Props
+
+Feel free to set these:
+*  __CoolMode__  
+  Default: *empty*  
+
+`[1:] // Remove initial newline
+
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
 })


### PR DESCRIPTION
this will stop displaying the props description message when there are no query/param props to override.

at least solves the confusion in https://github.com/containrrr/shoutrrr/discussions/176