### PR TITLE
fix(smtp): remove extra semi in mime header

### DIFF
--- a/pkg/services/smtp/smtp.go
+++ b/pkg/services/smtp/smtp.go
@@ -219,7 +219,7 @@ func (service *Service) getHeaders(toAddress string, subject string) map[string]
 		"Date":         time.Now().Format(time.RFC1123Z),
 		"To":           toAddress,
 		"From":         fmt.Sprintf("%s <%s>", conf.FromName, conf.FromAddress),
-		"MIME-version": "1.0;",
+		"MIME-version": "1.0",
 		"Content-Type": contentType,
 	}
 }


### PR DESCRIPTION
The `MIME-Version` header sent by the smtp service contained a trailing `;` which seems to sometimes cause SpamAssassin to trigger the `BOGUS_MIME_VERSION` rule. Upon testing, this happened roughly 1/5 of the time, using the exact same message.

When removing the trailing `;`, I have not been able to trigger the rule.

fixes #200 