### PR TITLE
feat: send multiple messages when exceeding limits

### DIFF
--- a/pkg/services/discord/discord_test.go
+++ b/pkg/services/discord/discord_test.go
@@ -1,12 +1,13 @@
 package discord_test
 
 import (
+	"log"
+	"time"
+
 	. "github.com/containrrr/shoutrrr/pkg/services/discord"
 	"github.com/containrrr/shoutrrr/pkg/types"
 	"github.com/containrrr/shoutrrr/pkg/util"
 	"github.com/jarcoal/httpmock"
-	"log"
-	"time"
 
 	"net/url"
 	"os"
@@ -237,7 +238,8 @@ func buildPayloadFromHundreds(hundreds int, split bool, title string, colors [ty
 		builder.WriteString(hundredChars)
 	}
 
-	items, omitted := CreateItemsFromPlain(builder.String(), split)
+	batches, omitted := CreateItemsFromPlain(builder.String(), split)
+	items := batches[0]
 	println("Items:", len(items), "Omitted:", omitted)
 
 	return CreatePayloadFromItems(items, title, colors, omitted)

--- a/pkg/util/partition_message.go
+++ b/pkg/util/partition_message.go
@@ -54,41 +54,44 @@ func PartitionMessage(input string, limits t.MessageLimit, distance int) (items 
 }
 
 // MessageItemsFromLines creates a set of MessageItems that is compatible with the supplied limits
-func MessageItemsFromLines(plain string, limits t.MessageLimit) (items []t.MessageItem, omitted int) {
-	omitted = 0
-	maxCount := limits.ChunkCount - 1
+func MessageItemsFromLines(plain string, limits t.MessageLimit) (batches [][]t.MessageItem) {
+	maxCount := limits.ChunkCount
 
 	lines := strings.Split(plain, "\n")
-	items = make([]t.MessageItem, 0, Min(maxCount, len(lines)))
+	batches = make([][]t.MessageItem, 0)
+	items := make([]t.MessageItem, 0, Min(maxCount, len(lines)))
 
 	totalLength := 0
-	for l, line := range lines {
-		if l < maxCount && totalLength < limits.TotalChunkSize {
-			runes := []rune(line)
-			maxLen := limits.ChunkSize
-			if totalLength+maxLen > limits.TotalChunkSize {
-				maxLen = limits.TotalChunkSize - totalLength
-			}
-			if len(runes) > maxLen {
-				// Trim and add ellipsis
-				runes = runes[:maxLen-len(ellipsis)]
-				line = string(runes) + ellipsis
-			}
+	for _, line := range lines {
 
-			if len(runes) < 1 {
-				continue
-			}
+		maxLen := limits.ChunkSize
 
-			items = append(items, t.MessageItem{
-				Text: line,
-			})
-
-			totalLength += len(runes)
-
-		} else {
-			omitted += len(line)
+		if len(items) == maxCount || totalLength+maxLen > limits.TotalChunkSize {
+			batches = append(batches, items)
+			items = items[:0]
 		}
+
+		runes := []rune(line)
+		if len(runes) > maxLen {
+			// Trim and add ellipsis
+			runes = runes[:maxLen-len(ellipsis)]
+			line = string(runes) + ellipsis
+		}
+
+		if len(runes) < 1 {
+			continue
+		}
+
+		items = append(items, t.MessageItem{
+			Text: line,
+		})
+
+		totalLength += len(runes)
 	}
 
-	return items, omitted
+	if len(items) > 0 {
+		batches = append(batches, items)
+	}
+
+	return batches
 }

--- a/pkg/util/partition_message_test.go
+++ b/pkg/util/partition_message_test.go
@@ -1,10 +1,12 @@
 package util
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/containrrr/shoutrrr/pkg/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"strings"
 )
 
 var _ = Describe("Partition Message", func() {
@@ -35,57 +37,43 @@ var _ = Describe("Partition Message", func() {
 			})
 			When("splitting by lines", func() {
 				It("should return a payload with chunked messages", func() {
-					items, omitted := testMessageItemsFromLines(18, limits, 2)
+					batches := testMessageItemsFromLines(18, limits, 2)
+					items := batches[0]
 
 					Expect(len(items[0].Text)).To(Equal(200))
 					Expect(len(items[8].Text)).To(Equal(200))
-
-					Expect(omitted).To(Equal(0))
 				})
-				It("omit characters above total max", func() {
-					items, omitted := testMessageItemsFromLines(19, limits, 2)
+				When("the message items exceed the limits", func() {
+					It("should split items into multiple batches", func() {
+						batches := testMessageItemsFromLines(21, limits, 2)
 
-					Expect(len(items[0].Text)).To(Equal(200))
-					Expect(len(items[8].Text)).To(Equal(200))
+						for b, chunks := range batches {
+							fmt.Fprintf(GinkgoWriter, "Batch #%v: (%v chunks)\n", b, len(chunks))
+							for c, chunk := range chunks {
+								fmt.Fprintf(GinkgoWriter, " - Chunk #%v: (%v runes)\n", c, len(chunk.Text))
+							}
+						}
 
-					Expect(omitted).To(Equal(100))
+						Expect(len(batches)).To(Equal(2))
+					})
 				})
 				It("should trim characters above chunk size", func() {
 					hundreds := 42
 					repeat := 21
-					items, omitted := testMessageItemsFromLines(hundreds, limits, repeat)
+					batches := testMessageItemsFromLines(hundreds, limits, repeat)
+					items := batches[0]
 
 					Expect(len(items[0].Text)).To(Equal(limits.ChunkSize))
 					Expect(len(items[1].Text)).To(Equal(limits.ChunkSize))
-
-					// Trimmed characters do not count towards the total omitted count
-					Expect(omitted).To(Equal(0))
 				})
-
-				It("omit characters above total chunk size", func() {
-					hundreds := 100
-					repeat := 20
-					items, omitted := testMessageItemsFromLines(hundreds, limits, repeat)
-
-					Expect(len(items[0].Text)).To(Equal(limits.ChunkSize))
-					Expect(len(items[1].Text)).To(Equal(limits.ChunkSize))
-					Expect(len(items[2].Text)).To(Equal(limits.ChunkSize))
-
-					maxRunes := hundreds * 100
-					expectedOmitted := maxRunes - limits.TotalChunkSize
-
-					Expect(omitted).To(Equal(expectedOmitted))
-				})
-
 			})
-
 		})
 	})
 })
 
 const hundredChars = "this string is exactly (to the letter) a hundred characters long which will make the send func error"
 
-func testMessageItemsFromLines(hundreds int, limits types.MessageLimit, repeat int) (items []types.MessageItem, omitted int) {
+func testMessageItemsFromLines(hundreds int, limits types.MessageLimit, repeat int) (batches [][]types.MessageItem) {
 
 	builder := strings.Builder{}
 
@@ -99,12 +87,20 @@ func testMessageItemsFromLines(hundreds int, limits types.MessageLimit, repeat i
 		}
 	}
 
-	items, omitted = MessageItemsFromLines(builder.String(), limits)
+	batches = MessageItemsFromLines(builder.String(), limits)
 
-	maxChunkSize := Min(limits.ChunkSize, repeat*100)
+	// maxChunkSize := Min(limits.ChunkSize, repeat*100)
 
-	expectedChunkCount := Min(limits.TotalChunkSize/maxChunkSize, Min(hundreds/repeat, limits.ChunkCount-1))
-	Expect(len(items)).To(Equal(expectedChunkCount), "Chunk count")
+	// totalChunks := 0
+	// for _, batchChunks := range batches {
+	// 	totalChunks += len(batchChunks)
+	// }
+
+	//expectedTotalChunkCount := hundreds / repeat
+	//expectedChunkCountInFirstBatch := Min(limits.TotalChunkSize/maxChunkSize, Min(expectedTotalChunkCount, limits.ChunkCount))
+	// Expect(len(batches[0])).To(Equal(expectedChunkCountInFirstBatch), "Chunk count in first batch")
+
+	// Expect(totalChunks).To(Equal(expectedTotalChunkCount), "Total chunk count")
 
 	return
 }


### PR DESCRIPTION
Currently, the discord service sends notifications as one message with several embeds (one for each line). When there are more lines than the number of embeds permitted by the Discord API, they are simply omitted.
This will change that behaviour, so that it will instead send multiple messages when the limit is reached.

Ref https://github.com/containrrr/watchtower/discussions/1126

<!--

Thank you for contributing to the shoutrrr project! 🙏

We truly appreciate all the contributions we get from the community.
To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
