### PR TITLE
Documenting the Service Schema for Generic

### DIFF
--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -26,5 +26,5 @@ Click on the service for a more thorough explanation. <!-- @formatter:off -->
 | Service                           | Description                                                                                                                                     |
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Logger](./logger.md)             | Writes notification to a configured go `log.Logger`                                                                                             |
-| [Generic Webhook](./generic.md)   | Sends notifications directly to a webhook                                                                                                       |
+| [Generic Webhook](./generic.md)   | *generic+https://`url`* to sends notifications directly to a webhook                                                                                                   |
 

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -26,5 +26,5 @@ Click on the service for a more thorough explanation. <!-- @formatter:off -->
 | Service                           | Description                                                                                                                                     |
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Logger](./logger.md)             | Writes notification to a configured go `log.Logger`                                                                                             |
-| [Generic Webhook](./generic.md)   | *generic+https://`url`* to sends notifications directly to a webhook                                                                                                   |
+| [Generic Webhook](./generic.md)   | *generic+https://`url`* to send notifications directly to a webhook                                                                                                   |
 


### PR DESCRIPTION
## PR for documenting explicitly the service schema for Generic

Took me about an hour to work out how to use `./shoutrrr send` for a generic request till I read through [the PR for generic](https://github.com/containrrr/shoutrrr/pull/144/files).
Hope this small change can help others.

I wanted to make changes the [generic service document](https://containrrr.dev/shoutrrr/v0.5/services/generic/) but I am not sure of what voodoo is going on as the linked file and directory at `docs/services/generic/config.md` does not exist in the repo!