### PR TITLE
ci: fix path to docs command

### DIFF
--- a/generate-service-config-docs.sh
+++ b/generate-service-config-docs.sh
@@ -7,7 +7,7 @@ function generate_docs() {
   DOCSPATH=./docs/services/$SERVICE
   echo -en "Creating docs for \e[96m$SERVICE\e[0m... "
   mkdir -p "$DOCSPATH"
-  go run ./cmd/shoutrrr docs -f markdown "$SERVICE" > "$DOCSPATH"/config.md
+  go run ./shoutrrr docs -f markdown "$SERVICE" > "$DOCSPATH"/config.md
   if [ $? ]; then
     echo -e "Done!"
   fi


### PR DESCRIPTION
When the shoutrrr cli changed path, the documentation script was not updated to reflect this. This should restore the CI docs publishing.
