### PR TITLE
docs: update telegram, matrix and cli output

### DIFF
--- a/docs/services/telegram.md
+++ b/docs/services/telegram.md
@@ -3,13 +3,36 @@
 ## URL Format
 
 !!! info ""
-    telegram://__`token`__@telegram?channels=__`channel-1`__[,__`channel-2`__,...]
+    telegram://__`token`__@telegram?chats=__`channel-1`__[,__`chat-id-1`__,...]
     
 --8<-- "docs/services/telegram/config.md"
 
 ## Getting a token for Telegram
 
 Talk to [the botfather](https://core.telegram.org/bots#6-botfather).
+
+## Identifying the target chats/channels
+
+The `chats` param consists of one or more `Chat ID`s or `channel name`s. 
+
+### Channels
+The channel names can be retrieved in the telegram client in the `Channel info` section. 
+Replace the `t.me/` prefix from the link with a `@`.
+
+!!! note
+    Channels names need to be prefixed by `@` to identify them as such.
+
+### Chats
+Group chats and private chats are identifieds by `Chat ID`s. Unfortunatly, they are generally not visible in the
+telegram clients.
+The easiest way to retrieve them is by using the `shoutrrr generate telegram` command which will guide you through
+creating a URL with your target chats.
+
+!!! tip
+    You can use the `containrrr/shoutrrr` image in docker to run it without download/installing the `shoutrrr` CLI using:
+    ```
+    docker run --rm -it containrrr/shoutrrr generate telegram
+    ```
 
 ## Optional parameters
 

--- a/pkg/format/render_console.go
+++ b/pkg/format/render_console.go
@@ -37,6 +37,12 @@ func (r ConsoleTreeRenderer) RenderTree(root *ContainerNode, _ string) string {
 		} else {
 			// Since no values was supplied, let's substitute the value with the type
 			typeName := field.Type.String()
+
+			// If the value is an enum type, providing the name is a bit pointless
+			// Instead, use a common string "option" to signify the type
+			if field.EnumFormatter != nil {
+				typeName = "option"
+			}
 			valueLen = len(typeName)
 			sb.WriteString(color.CyanString(typeName))
 		}

--- a/pkg/format/render_console_test.go
+++ b/pkg/format/render_console_test.go
@@ -24,6 +24,16 @@ Name string                                                                     
 		Expect(actual).To(Equal(expected))
 	})
 
+	It(`should render enum types as "option"`, func() {
+		actual := testRenderTree(renderer, &testEnummer{})
+
+		expected := `
+Choice option                                                                       <Default: Maybe> [Yes, No, Maybe]
+`[1:]
+
+		Expect(actual).To(Equal(expected))
+	})
+
 	It("should render url paths in sorted order", func() {
 		actual := testRenderTree(renderer, &struct {
 			Host  string `url:"host"`

--- a/pkg/services/matrix/matrix_client.go
+++ b/pkg/services/matrix/matrix_client.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/containrrr/shoutrrr/pkg/types"
-	"github.com/containrrr/shoutrrr/pkg/util"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/containrrr/shoutrrr/pkg/types"
+	"github.com/containrrr/shoutrrr/pkg/util"
 )
 
 type client struct {

--- a/pkg/services/matrix/matrix_config.go
+++ b/pkg/services/matrix/matrix_config.go
@@ -1,21 +1,22 @@
 package matrix
 
 import (
+	"net/url"
+
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	t "github.com/containrrr/shoutrrr/pkg/types"
-	"net/url"
 )
 
 // Config is the configuration for the matrix service
 type Config struct {
 	standard.EnumlessConfig
 
-	User       string `optional:""`
-	Password   string
-	DisableTLS bool `key:"disableTLS" default:"No"`
-	Host       string
-	Rooms      []string `key:"rooms,room" optional:""`
+	User       string   `optional:"" url:"user" desc:"Username or empty when using access token"`
+	Password   string   `url:"password" desc:"Password or access token"`
+	DisableTLS bool     `key:"disableTLS" default:"No"`
+	Host       string   `url:"host"`
+	Rooms      []string `key:"rooms,room" optional:"" desc:"Room aliases, or with ! prefix, room IDs"`
 	Title      string   `key:"title" default:""`
 }
 

--- a/pkg/services/telegram/telegram_config.go
+++ b/pkg/services/telegram/telegram_config.go
@@ -3,10 +3,11 @@ package telegram
 import (
 	"errors"
 	"fmt"
-	"github.com/containrrr/shoutrrr/pkg/format"
-	"github.com/containrrr/shoutrrr/pkg/types"
 	"net/url"
 	"strings"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
 )
 
 // Config for use within the telegram plugin
@@ -15,7 +16,7 @@ type Config struct {
 	Preview      bool      `key:"preview" default:"Yes" desc:"If disabled, no web page preview will be displayed for URLs"`
 	Notification bool      `key:"notification" default:"Yes" desc:"If disabled, sends Message silently"`
 	ParseMode    parseMode `key:"parsemode" default:"None" desc:"How the text Message should be parsed"`
-	Chats        []string  `key:"chats,channels"`
+	Chats        []string  `key:"chats,channels" desc:"Chat IDs or Channel names (using @channel-name)"`
 	Title        string    `key:"title" default:"" desc:"Notification title, optionally set by the sender"`
 }
 


### PR DESCRIPTION
Bulk updates to the documentation, clarifying `telegram` chats and matrix `URL` schema.
Also replaces the enum types in `shoutrrr docs` with a static `option` string when using the console renderer.