### PR TITLE
fix(gotify): handle token ending in /

### DIFF
--- a/internal/testutils/mockclientservice.go
+++ b/internal/testutils/mockclientservice.go
@@ -1,0 +1,8 @@
+package testutils
+
+import "net/http"
+
+// MockClientService is used to allow mocking the HTTP client when testing
+type MockClientService interface {
+	GetHTTPClient() *http.Client
+}

--- a/pkg/services/gotify/gotify_config.go
+++ b/pkg/services/gotify/gotify_config.go
@@ -1,10 +1,11 @@
 package gotify
 
 import (
-	"github.com/containrrr/shoutrrr/pkg/format"
-	"github.com/containrrr/shoutrrr/pkg/types"
 	"net/url"
 	"strings"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
 
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 )
@@ -44,11 +45,19 @@ func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
 
 func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) error {
 
-	tokenIndex := strings.LastIndex(url.Path, "/")
-	config.Path = url.Path[:tokenIndex]
+	path := url.Path
+	if len(path) > 0 && path[len(path)-1] == '/' {
+		path = path[:len(path)-1]
+	}
+	tokenIndex := strings.LastIndex(path, "/") + 1
+
+	config.Path = path[:tokenIndex]
+	if config.Path == "/" {
+		config.Path = config.Path[1:]
+	}
 
 	config.Host = url.Host
-	config.Token = url.Path[tokenIndex:]
+	config.Token = path[tokenIndex:]
 
 	for key, vals := range url.Query() {
 		if err := resolver.Set(key, vals[0]); err != nil {

--- a/pkg/services/gotify/gotify_json.go
+++ b/pkg/services/gotify/gotify_json.go
@@ -1,8 +1,27 @@
 package gotify
 
-// JSON is the actual payload being sent to the Gotify API
-type JSON struct {
+import "fmt"
+
+// messageRequest is the actual payload being sent to the Gotify API
+type messageRequest struct {
 	Message  string `json:"message"`
 	Title    string `json:"title"`
 	Priority int    `json:"priority"`
+}
+
+type messageResponse struct {
+	messageRequest
+	ID    uint64 `json:"id"`
+	AppID uint64 `json:"appid"`
+	Date  string `json:"date"`
+}
+
+type errorResponse struct {
+	Name        string `json:"error"`
+	Code        uint64 `json:"errorCode"`
+	Description string `json:"errorDescription"`
+}
+
+func (er *errorResponse) Error() string {
+	return fmt.Sprintf("server respondend with %v (%v): %v", er.Name, er.Code, er.Description)
 }

--- a/pkg/services/gotify/gotify_test.go
+++ b/pkg/services/gotify/gotify_test.go
@@ -2,11 +2,13 @@ package gotify
 
 import (
 	"errors"
-	"github.com/jarcoal/httpmock"
 	"log"
 	"net/url"
 	"testing"
 
+	"github.com/containrrr/shoutrrr/internal/testutils"
+
+	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -81,31 +83,36 @@ var _ = Describe("the Gotify plugin URL building and token validation functions"
 			It("should be identical after de-/serialization (with path)", func() {
 				testURL := "gotify://my.gotify.tld/gotify/Aaa.bbb.ccc.ddd?title=Test+title"
 
-				url, err := url.Parse(testURL)
-				Expect(err).NotTo(HaveOccurred(), "parsing")
-
 				config := &Config{}
-				err = config.SetURL(url)
-				Expect(err).NotTo(HaveOccurred(), "verifying")
-
-				outputURL := config.GetURL()
-				Expect(outputURL.String()).To(Equal(testURL))
-
+				Expect(config.SetURL(testutils.URLMust(testURL))).To(Succeed())
+				Expect(config.GetURL().String()).To(Equal(testURL))
 			})
 			It("should be identical after de-/serialization (without path)", func() {
 				testURL := "gotify://my.gotify.tld/Aaa.bbb.ccc.ddd?disabletls=Yes&priority=1&title=Test+title"
 
-				url, err := url.Parse(testURL)
-				Expect(err).NotTo(HaveOccurred(), "parsing")
+				config := &Config{}
+				Expect(config.SetURL(testutils.URLMust(testURL))).To(Succeed())
+				Expect(config.GetURL().String()).To(Equal(testURL))
+
+			})
+			It("should allow slash at the end of the token", func() {
+				url := testutils.URLMust("gotify://my.gotify.tld/Aaa.bbb.ccc.ddd/")
 
 				config := &Config{}
-				err = config.SetURL(url)
-				Expect(err).NotTo(HaveOccurred(), "verifying")
+				Expect(config.SetURL(url)).To(Succeed())
+				Expect(config.Token).To(Equal("Aaa.bbb.ccc.ddd"))
+			})
+			It("should allow slash at the end of the token, with additional path", func() {
+				url := testutils.URLMust("gotify://my.gotify.tld/path/to/gotify/Aaa.bbb.ccc.ddd/")
 
-				outputURL := config.GetURL()
-
-				Expect(outputURL.String()).To(Equal(testURL))
-
+				config := &Config{}
+				Expect(config.SetURL(url)).To(Succeed())
+				Expect(config.Token).To(Equal("Aaa.bbb.ccc.ddd"))
+			})
+			It("should not crash on empty token or path slash at the end of the token", func() {
+				config := &Config{}
+				Expect(config.SetURL(testutils.URLMust("gotify://my.gotify.tld//"))).To(Succeed())
+				Expect(config.SetURL(testutils.URLMust("gotify://my.gotify.tld/"))).To(Succeed())
 			})
 		})
 	})
@@ -119,11 +126,11 @@ var _ = Describe("the Gotify plugin URL building and token validation functions"
 		It("should not report an error if the server accepts the payload", func() {
 			serviceURL, _ := url.Parse("gotify://my.gotify.tld/Aaa.bbb.ccc.ddd")
 			err = service.Initialize(serviceURL, logger)
-			httpmock.ActivateNonDefault(service.Client)
+			httpmock.ActivateNonDefault(service.httpClient)
 			Expect(err).NotTo(HaveOccurred())
 
 			targetURL := "https://my.gotify.tld/message?token=Aaa.bbb.ccc.ddd"
-			httpmock.RegisterResponder("POST", targetURL, httpmock.NewStringResponder(200, ""))
+			httpmock.RegisterResponder("POST", targetURL, testutils.JSONRespondMust(200, messageResponse{}))
 
 			err = service.Send("Message", nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -131,7 +138,7 @@ var _ = Describe("the Gotify plugin URL building and token validation functions"
 		It("should not panic if an error occurs when sending the payload", func() {
 			serviceURL, _ := url.Parse("gotify://my.gotify.tld/Aaa.bbb.ccc.ddd")
 			err = service.Initialize(serviceURL, logger)
-			httpmock.ActivateNonDefault(service.Client)
+			httpmock.ActivateNonDefault(service.httpClient)
 			Expect(err).NotTo(HaveOccurred())
 
 			targetURL := "https://my.gotify.tld/message?token=Aaa.bbb.ccc.ddd"

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -1,13 +1,14 @@
 package services_test
 
 import (
-	"github.com/containrrr/shoutrrr/pkg/router"
-	"github.com/containrrr/shoutrrr/pkg/services/gotify"
-	"github.com/containrrr/shoutrrr/pkg/types"
-	"github.com/jarcoal/httpmock"
 	"log"
 	"net/http"
 	"testing"
+
+	"github.com/containrrr/shoutrrr/internal/testutils"
+	"github.com/containrrr/shoutrrr/pkg/router"
+	"github.com/containrrr/shoutrrr/pkg/types"
+	"github.com/jarcoal/httpmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -41,6 +42,7 @@ var serviceURLs = map[string]string{
 
 var serviceResponses = map[string]string{
 	"pushbullet": `{"created": 0}`,
+	"gotify":     `{"id": 0}`,
 }
 
 var logger = log.New(GinkgoWriter, "Test", log.LstdFlags)
@@ -88,9 +90,8 @@ var _ = Describe("services", func() {
 				service, err := serviceRouter.Locate(configURL)
 				Expect(err).NotTo(HaveOccurred())
 
-				if key == "gotify" {
-					gotifyService := service.(*gotify.Service)
-					httpmock.ActivateNonDefault(gotifyService.Client)
+				if mockService, ok := service.(testutils.MockClientService); ok {
+					httpmock.ActivateNonDefault(mockService.GetHTTPClient())
 				}
 
 				err = service.Send("test", (*types.Params)(&map[string]string{

--- a/pkg/util/jsonclient/jsonclient.go
+++ b/pkg/util/jsonclient/jsonclient.go
@@ -31,9 +31,15 @@ type client struct {
 	indent     string
 }
 
+// NewClient returns a new JSON Client using the default http.Client
 func NewClient() Client {
+	return NewWithHTTPClient(http.DefaultClient)
+}
+
+// NewWithHTTPClient returns a new JSON Client using the specified http.Client
+func NewWithHTTPClient(httpClient *http.Client) Client {
 	return &client{
-		httpClient: http.DefaultClient,
+		httpClient: httpClient,
 		headers: http.Header{
 			"Content-Type": []string{ContentType},
 		},


### PR DESCRIPTION
This fixes a problem in gotify service, where it would not correctly handle a URL with only a token, but ending in `/`.
It also provides the full error messages as returned by the server upon failure.