### PR TITLE
chore(discord): switch from deprecated discordapp.com domain

### DIFF
--- a/docs/services/discord.md
+++ b/docs/services/discord.md
@@ -5,7 +5,7 @@
 Your Discord Webhook-URL will look like this:
 
 !!! info ""
-    https://discordapp.com/api/webhooks/__`webhookid`__/__`token`__  
+    https://discord.com/api/webhooks/__`webhookid`__/__`token`__  
 
 The shoutrrr service URL should look like this:  
 
@@ -33,7 +33,7 @@ The shoutrrr service URL should look like this:
 
 6. Format the service URL
 ```
-https://discordapp.com/api/webhooks/693853386302554172/W3dE2OZz4C13_4z_uHfDOoC7BqTW288s-z1ykqI0iJnY_HjRqMGO8Sc7YDqvf_KVKjhJ
+https://discord.com/api/webhooks/693853386302554172/W3dE2OZz4C13_4z_uHfDOoC7BqTW288s-z1ykqI0iJnY_HjRqMGO8Sc7YDqvf_KVKjhJ
                                     └────────────────┘ └──────────────────────────────────────────────────────────────────┘
                                         webhook id                                    token
 

--- a/pkg/services/discord/discord.go
+++ b/pkg/services/discord/discord.go
@@ -26,7 +26,7 @@ var limits = types.MessageLimit{
 }
 
 const (
-	hookURL = "https://discordapp.com/api/webhooks"
+	hookURL = "https://discord.com/api/webhooks"
 	// Only search this many runes for a good split position
 	maxSearchRunes = 100
 )


### PR DESCRIPTION
<!--

Thank you for contributing to the shoutrrr project! 🙏

We truly appreciate all the contributions we get from the community.
To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
Currently, the Discord service is making requests to the [deprecated `discordapp.com` domain](https://github.com/discord/discord-api-docs/issues/1585#issuecomment-623751530). We should switch to the `discord.com` domain to prevent downtime in the future.