### PR TITLE
feat(mattermost): add support for icons

### DIFF
--- a/docs/services/mattermost.md
+++ b/docs/services/mattermost.md
@@ -3,7 +3,7 @@
 ## URL Format
 
 !!! info ""
-    mattermost://[__`username`__@]__`mattermost-host`__/__`token`__[/__`channel`__]
+    mattermost://[__`username`__@]__`mattermost-host`__/__`token`__[/__`channel`__][?icon=__`smiley`__]
 
 --8<-- "docs/services/mattermost/config.md"
 
@@ -59,6 +59,7 @@ params := (*types.Params)(
 	&map[string]string{
 		"username": "overwriteUserName",
 		"channel": "overwriteChannel",
+        "icon": "overwriteIcon",
 	},
 )
 

--- a/pkg/services/mattermost/mattermost.go
+++ b/pkg/services/mattermost/mattermost.go
@@ -24,11 +24,7 @@ func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) e
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
 	service.pkr = format.NewPropKeyResolver(service.config)
-	if err := service.config.setURL(&service.pkr, configURL); err != nil {
-		return err
-	}
-
-	return nil
+	return service.config.setURL(&service.pkr, configURL)
 }
 
 // Send a notification message to Mattermost

--- a/pkg/services/mattermost/mattermost.go
+++ b/pkg/services/mattermost/mattermost.go
@@ -3,9 +3,11 @@ package mattermost
 import (
 	"bytes"
 	"fmt"
-	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	"net/http"
 	"net/url"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/services/standard"
 
 	"github.com/containrrr/shoutrrr/pkg/types"
 )
@@ -14,13 +16,15 @@ import (
 type Service struct {
 	standard.Standard
 	config *Config
+	pkr    format.PropKeyResolver
 }
 
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
 func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
 	service.config = &Config{}
-	if err := service.config.SetURL(configURL); err != nil {
+	service.pkr = format.NewPropKeyResolver(service.config)
+	if err := service.config.setURL(&service.pkr, configURL); err != nil {
 		return err
 	}
 
@@ -31,6 +35,10 @@ func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) e
 func (service *Service) Send(message string, params *types.Params) error {
 	config := service.config
 	apiURL := buildURL(config)
+
+	if err := service.pkr.UpdateConfigFromParams(config, params); err != nil {
+		return err
+	}
 	json, _ := CreateJSONPayload(config, message, params)
 	res, err := http.Post(apiURL, "application/json", bytes.NewReader(json))
 	if err != nil {

--- a/pkg/services/mattermost/mattermost_config.go
+++ b/pkg/services/mattermost/mattermost_config.go
@@ -2,15 +2,19 @@ package mattermost
 
 import (
 	"errors"
-	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	"net/url"
 	"strings"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/services/standard"
+	"github.com/containrrr/shoutrrr/pkg/types"
 )
 
 //Config object holding all information
 type Config struct {
 	standard.EnumlessConfig
 	UserName string `url:"user" optional:"" desc:"Override webhook user"`
+	Icon     string `key:"icon,icon_emoji,icon_url" default:"" optional:"" desc:"Use emoji or URL as icon (based on presence of http(s):// prefix)"`
 	Channel  string `url:"path2" optional:"" desc:"Override webhook channel"`
 	Host     string `url:"host,port" desc:"Mattermost server host"`
 	Token    string `url:"path1" desc:"Webhook token"`
@@ -36,7 +40,12 @@ func (config *Config) GetURL() *url.URL {
 }
 
 // SetURL updates a ServiceConfig from a URL representation of it's field values
-func (config *Config) SetURL(serviceURL *url.URL) error {
+func (config *Config) SetURL(url *url.URL) error {
+	resolver := format.NewPropKeyResolver(config)
+	return config.setURL(&resolver, url)
+}
+
+func (config *Config) setURL(resolver types.ConfigQueryResolver, serviceURL *url.URL) error {
 
 	config.Host = serviceURL.Hostname()
 	if serviceURL.Path == "" || serviceURL.Path == "/" {
@@ -44,6 +53,12 @@ func (config *Config) SetURL(serviceURL *url.URL) error {
 	}
 	config.UserName = serviceURL.User.Username()
 	path := strings.Split(serviceURL.Path[1:], "/")
+
+	for key, vals := range serviceURL.Query() {
+		if err := resolver.Set(key, vals[0]); err != nil {
+			return err
+		}
+	}
 
 	if len(path) < 1 {
 		return errors.New(string(NotEnoughArguments))
@@ -68,3 +83,10 @@ const (
 	// NotEnoughArguments provided in the service URL
 	NotEnoughArguments ErrorMessage = "the apiURL does not include enough arguments, either provide 1 or 3 arguments (they may be empty)"
 )
+
+// CreateConfigFromURL to use within the mattermost service
+func CreateConfigFromURL(serviceURL *url.URL) (*Config, error) {
+	config := Config{}
+	err := config.SetURL(serviceURL)
+	return &config, err
+}

--- a/pkg/services/mattermost/mattermost_config.go
+++ b/pkg/services/mattermost/mattermost_config.go
@@ -15,6 +15,7 @@ type Config struct {
 	standard.EnumlessConfig
 	UserName string `url:"user" optional:"" desc:"Override webhook user"`
 	Icon     string `key:"icon,icon_emoji,icon_url" default:"" optional:"" desc:"Use emoji or URL as icon (based on presence of http(s):// prefix)"`
+	Title    string `key:"title" default:"" desc:"Notification title, optionally set by the sender (not used)"`
 	Channel  string `url:"path2" optional:"" desc:"Override webhook channel"`
 	Host     string `url:"host,port" desc:"Mattermost server host"`
 	Token    string `url:"path1" desc:"Webhook token"`

--- a/pkg/services/mattermost/mattermost_config.go
+++ b/pkg/services/mattermost/mattermost_config.go
@@ -31,12 +31,14 @@ func (config *Config) GetURL() *url.URL {
 	if config.UserName != "" {
 		user = url.User(config.UserName)
 	}
+	resolver := format.NewPropKeyResolver(config)
 	return &url.URL{
 		User:       user,
 		Host:       config.Host,
 		Path:       strings.Join(paths, "/"),
 		Scheme:     Scheme,
 		ForceQuery: false,
+		RawQuery:   format.BuildQuery(&resolver),
 	}
 }
 

--- a/pkg/services/mattermost/mattermost_json.go
+++ b/pkg/services/mattermost/mattermost_json.go
@@ -2,15 +2,34 @@ package mattermost
 
 import (
 	"encoding/json"
+	"regexp"
 
 	"github.com/containrrr/shoutrrr/pkg/types"
 )
 
 // JSON payload for mattermost notifications
 type JSON struct {
-	Text     string `json:"text"`
-	UserName string `json:"username,omitempty"`
-	Channel  string `json:"channel,omitempty"`
+	Text      string `json:"text"`
+	UserName  string `json:"username,omitempty"`
+	Channel   string `json:"channel,omitempty"`
+	IconEmoji string `json:"icon_emoji,omitempty"`
+	IconURL   string `json:"icon_url,omitempty"`
+}
+
+var iconURLPattern = regexp.MustCompile(`https?://`)
+
+// SetIcon sets the appropriate icon field in the payload based on whether the input is a URL or not
+func (j *JSON) SetIcon(icon string) {
+	j.IconURL = ""
+	j.IconEmoji = ""
+
+	if icon != "" {
+		if iconURLPattern.MatchString(icon) {
+			j.IconURL = icon
+		} else {
+			j.IconEmoji = icon
+		}
+	}
 }
 
 // CreateJSONPayload for usage with the mattermost service
@@ -29,5 +48,7 @@ func CreateJSONPayload(config *Config, message string, params *types.Params) ([]
 			payload.Channel = value
 		}
 	}
+	payload.SetIcon(config.Icon)
+
 	return json.Marshal(payload)
 }

--- a/pkg/services/mattermost/mattermost_test.go
+++ b/pkg/services/mattermost/mattermost_test.go
@@ -111,6 +111,42 @@ var _ = Describe("the mattermost service", func() {
 			})
 		})
 	})
+	When("generating a config object", func() {
+		It("should not set icon", func() {
+			slackURL, _ := url.Parse("mattermost://AAAAAAAAA/BBBBBBBBB")
+			config, configError := CreateConfigFromURL(slackURL)
+
+			Expect(configError).NotTo(HaveOccurred())
+			Expect(config.Icon).To(BeEmpty())
+		})
+		It("should set icon", func() {
+			slackURL, _ := url.Parse("mattermost://AAAAAAAAA/BBBBBBBBB?icon=test")
+			config, configError := CreateConfigFromURL(slackURL)
+
+			Expect(configError).NotTo(HaveOccurred())
+			Expect(config.Icon).To(BeIdenticalTo("test"))
+		})
+	})
+	Describe("creating the payload", func() {
+		Describe("the icon fields", func() {
+			payload := JSON{}
+			It("should set IconURL when the configured icon looks like an URL", func() {
+				payload.SetIcon("https://example.com/logo.png")
+				Expect(payload.IconURL).To(Equal("https://example.com/logo.png"))
+				Expect(payload.IconEmoji).To(BeEmpty())
+			})
+			It("should set IconEmoji when the configured icon does not look like an URL", func() {
+				payload.SetIcon("tanabata_tree")
+				Expect(payload.IconEmoji).To(Equal("tanabata_tree"))
+				Expect(payload.IconURL).To(BeEmpty())
+			})
+			It("should clear both fields when icon is empty", func() {
+				payload.SetIcon("")
+				Expect(payload.IconEmoji).To(BeEmpty())
+				Expect(payload.IconURL).To(BeEmpty())
+			})
+		})
+	})
 	Describe("Sending messages", func() {
 		When("sending a message completely without parameters", func() {
 			mattermostURL, _ := url.Parse("mattermost://mattermost.my-domain.com/thisshouldbeanapitoken")

--- a/pkg/services/mattermost/mattermost_test.go
+++ b/pkg/services/mattermost/mattermost_test.go
@@ -285,7 +285,7 @@ var _ = Describe("the mattermost service", func() {
 				httpmock.DeactivateAndReset()
 			})
 			It("should implement basic service API methods correctly", func() {
-				serviceURL := testutils.URLMust("bark://mockhost/mocktoken")
+				serviceURL := testutils.URLMust("mattermost://mockhost/mocktoken")
 				Expect(service.Initialize(serviceURL, testutils.TestLogger())).To(Succeed())
 				testutils.TestServiceSetInvalidParamValue(service, "foo", "bar")
 			})

--- a/pkg/services/mattermost/mattermost_test.go
+++ b/pkg/services/mattermost/mattermost_test.go
@@ -220,4 +220,31 @@ var _ = Describe("the mattermost service", func() {
 		})
 
 	})
+	
+	Describe("the basic service API", func() {
+		Describe("the service config", func() {
+			It("should implement basic service config API methods correctly", func() {
+				testutils.TestConfigGetInvalidQueryValue(&Config{})
+				testutils.TestConfigSetInvalidQueryValue(&Config{}, "bark://:mock-device@host/?foo=bar")
+
+				testutils.TestConfigSetDefaultValues(&Config{})
+
+				testutils.TestConfigGetEnumsCount(&Config{}, 0)
+				testutils.TestConfigGetFieldsCount(&Config{}, 9)
+			})
+		})
+		Describe("the service instance", func() {
+			BeforeEach(func() {
+				httpmock.Activate()
+			})
+			AfterEach(func() {
+				httpmock.DeactivateAndReset()
+			})
+			It("should implement basic service API methods correctly", func() {
+				serviceURL := testutils.URLMust("bark://:devicekey@hostname")
+				Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+				testutils.TestServiceSetInvalidParamValue(service, "foo", "bar")
+			})
+		})
+	})
 })


### PR DESCRIPTION
- What your PR contributes
Icon support on MatterMost:
```bash
./shoutrrr send -u 'mattermost://Argus@mattermost.example.io:443/xxxxxxxxxxx?icon_emoji=https%3A%2F%2Fraw.githubusercontent.com%2Fcontainrrr%2Fshoutrrr%2Fmain%2Fdocs%2Fshoutrrr-logotype.png' -m 'Icon Test'
./shoutrrr send -u 'mattermost://Argus@mattermost.example.io:443/xxxxxxxxxxx?icon_emoji=smiley' -m 'Icon Test'
```
![image](https://user-images.githubusercontent.com/4267227/168822741-979783f4-32b8-4e0b-9570-3465434fc11b.png)

- Which issues it solves
Moving my [Argus](https://github.com/release-argus/Argus/issues/33) project to use Shoutrrr. Really want to keep icon support!

- Tests that verify the code your contributing
I tried adding tests (and most of this code is copied from the Slack service), but couldn't get them to pass. Every other service that has query params seems to include the `title` param, but that's no supported on MatterMost, so I'm not sure what to do w.r.t this error. Help fixing this would be appreciated!
```bash
• Failure [0.000 seconds]
services
/path/to/shoutrrr/pkg/services/services_test.go:48
  when passed the a title param
  /path/to/shoutrrr/pkg/services/services_test.go:57
    should not throw an error for mattermost [It]
    /path/to/shoutrrr/pkg/services/services_test.go:71

    Unexpected error:
        <*errors.errorString | 0xc00030e1b0>: {
            s: "title is not a valid config key [icon icon_emoji icon_url]",
        }
        title is not a valid config key [icon icon_emoji icon_url]
    occurred

    /path/to/shoutrrr/pkg/services/services_test.go:99
```

- Updates to the documentation
Done? Let me know if you'd like any more, or changes to them. (Hoping the 'The services does not support any query/param props' would go away with this current commit?)
