### PR TITLE
fix(slack): limit attachments to 100

### DIFF
--- a/pkg/services/slack/slack_json.go
+++ b/pkg/services/slack/slack_json.go
@@ -73,11 +73,22 @@ type APIResponse struct {
 func CreateJSONPayload(config *Config, message string) interface{} {
 
 	var atts []attachment
-	for _, line := range strings.Split(message, "\n") {
+	for i, line := range strings.Split(message, "\n") {
+		// When 100 attachments have been reached, append the remaining line to the last
+		// attachment to prevent reaching the slack API limit
+		if i >= 100 {
+			atts[len(atts)-1].Text += "\n" + line
+			continue
+		}
 		atts = append(atts, attachment{
 			Text:  line,
 			Color: config.Color,
 		})
+	}
+
+	// Remove last attachment if empty
+	if atts[len(atts)-1].Text == "" {
+		atts = atts[:len(atts)-1]
 	}
 
 	payload := MessagePayload{


### PR DESCRIPTION
also removes last attachment if text is empty

fixes #238

<!--

Thank you for contributing to the shoutrrr project! 🙏

We truly appreciate all the contributions we get from the community.
To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
