### PR TITLE
discord message size fixes

### DIFF
--- a/pkg/services/discord/discord_json.go
+++ b/pkg/services/discord/discord_json.go
@@ -2,16 +2,17 @@ package discord
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/containrrr/shoutrrr/pkg/types"
 	"github.com/containrrr/shoutrrr/pkg/util"
-	"time"
 )
 
 // WebhookPayload is the webhook endpoint payload
 type WebhookPayload struct {
-	Embeds   []embedItem `json:"embeds"`
-	Username string      `json:"username,omitempty"`
-	AvatarURL string     `json:"avatar_url,omitempty"`
+	Embeds    []embedItem `json:"embeds"`
+	Username  string      `json:"username,omitempty"`
+	AvatarURL string      `json:"avatar_url,omitempty"`
 }
 
 // JSON is the actual notification payload
@@ -31,6 +32,10 @@ type embedFooter struct {
 
 // CreatePayloadFromItems creates a JSON payload to be sent to the discord webhook API
 func CreatePayloadFromItems(items []types.MessageItem, title string, colors [types.MessageLevelCount]uint, omitted int) (WebhookPayload, error) {
+
+	if len(items) < 1 {
+		return WebhookPayload{}, fmt.Errorf("message is empty")
+	}
 
 	metaCount := 1
 	if omitted < 1 && len(title) < 1 {
@@ -65,10 +70,14 @@ func CreatePayloadFromItems(items []types.MessageItem, title string, colors [typ
 		embeds = append(embeds, ei)
 	}
 
-	embeds[0].Title = title
-	if omitted > 0 {
-		embeds[0].Footer = &embedFooter{
-			Text: fmt.Sprintf("... (%v character(s) where omitted)", omitted),
+	// This should not happen, but it's better to leave the index check before dereferencing the array
+	if len(embeds) > 0 {
+		embeds[0].Title = title
+
+		if omitted > 0 {
+			embeds[0].Footer = &embedFooter{
+				Text: fmt.Sprintf("... (%v character(s) where omitted)", omitted),
+			}
 		}
 	}
 

--- a/pkg/services/discord/discord_json.go
+++ b/pkg/services/discord/discord_json.go
@@ -76,7 +76,7 @@ func CreatePayloadFromItems(items []types.MessageItem, title string, colors [typ
 
 		if omitted > 0 {
 			embeds[0].Footer = &embedFooter{
-				Text: fmt.Sprintf("... (%v character(s) where omitted)", omitted),
+				Text: fmt.Sprintf("... (%v character(s) were omitted)", omitted),
 			}
 		}
 	}

--- a/pkg/services/discord/discord_test.go
+++ b/pkg/services/discord/discord_test.go
@@ -247,6 +247,15 @@ var _ = Describe("the discord service", func() {
 			Expect(service.Initialize(dummyConfig.GetURL(), logger)).To(Succeed())
 			Expect(service.Send("", nil)).NotTo(Succeed())
 		})
+		When("using a custom json payload", func() {
+			It("should report an error if the server response is not OK", func() {
+				config := dummyConfig
+				config.JSON = true
+				setupResponder(&config, 400, "")
+				Expect(service.Initialize(config.GetURL(), logger)).To(Succeed())
+				Expect(service.Send("Message", nil)).NotTo(Succeed())
+			})
+		})
 	})
 })
 

--- a/pkg/services/discord/discord_test.go
+++ b/pkg/services/discord/discord_test.go
@@ -115,12 +115,24 @@ var _ = Describe("the discord service", func() {
 		})
 	})
 	Describe("creating a json payload", func() {
-		//When("given a blank message", func() {
-		//	It("should return an error", func() {
-		//		_, err := CreatePayloadFromItems("", false)
-		//		Expect(err).To(HaveOccurred())
-		//	})
-		//})
+		When("given a blank message", func() {
+			When("split lines is enabled", func() {
+				It("should return an error", func() {
+					items, omitted := CreateItemsFromPlain("", true)
+					Expect(items).To(BeEmpty())
+					_, err := CreatePayloadFromItems(items, "title", dummyColors, omitted)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+			When("split lines is disabled", func() {
+				It("should return an error", func() {
+					items, omitted := CreateItemsFromPlain("", false)
+					Expect(items).To(BeEmpty())
+					_, err := CreatePayloadFromItems(items, "title", dummyColors, omitted)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
 		When("given a message that exceeds the max length", func() {
 			It("should return a payload with chunked messages", func() {
 

--- a/pkg/util/partition_message.go
+++ b/pkg/util/partition_message.go
@@ -25,10 +25,10 @@ func PartitionMessage(input string, limits t.MessageLimit, distance int) (items 
 	}
 
 	for i := 0; i < maxCount; i++ {
-		// If no suitable split point is found, use the chunkSize
-		chunkEnd := chunkOffset + limits.ChunkSize
-		// ... and start next chunk directly after this one
-		nextChunkStart := chunkEnd
+		// If no suitable split point is found, start next chunk at chunkSize from chunk start
+		nextChunkStart := chunkOffset + limits.ChunkSize
+		// ... and set the chunk end to the rune before the next chunk
+		chunkEnd := nextChunkStart - 1
 		if chunkEnd > maxTotal {
 			// The chunk is smaller than the limit, no need to search
 			chunkEnd = maxTotal

--- a/pkg/util/partition_message.go
+++ b/pkg/util/partition_message.go
@@ -18,6 +18,12 @@ func PartitionMessage(input string, limits t.MessageLimit, distance int) (items 
 	maxTotal := Min(len(runes), limits.TotalChunkSize)
 	maxCount := limits.ChunkCount - 1
 
+	if len(input) == 0 {
+		// If the message is empty, return an empty array
+		omitted = 0
+		return
+	}
+
 	for i := 0; i < maxCount; i++ {
 		// If no suitable split point is found, use the chunkSize
 		chunkEnd := chunkOffset + limits.ChunkSize

--- a/pkg/util/partition_message_test.go
+++ b/pkg/util/partition_message_test.go
@@ -42,6 +42,13 @@ var _ = Describe("Partition Message", func() {
 				Expect(len(items[1].Text)).To(Equal(1999))
 				Expect(len(items[2].Text)).To(Equal(5))
 			})
+			When("the message is empty", func() {
+				It("should return no items", func() {
+					items, _ := testPartitionMessage(0, limits, 100)
+					Expect(items).To(BeEmpty())
+				})
+			})
+
 		})
 		When("splitting by lines", func() {
 			It("should return a payload with chunked messages", func() {

--- a/pkg/util/partition_message_test.go
+++ b/pkg/util/partition_message_test.go
@@ -1,85 +1,94 @@
 package util
 
 import (
+	"strings"
+
 	"github.com/containrrr/shoutrrr/pkg/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"strings"
 )
 
 var _ = Describe("Partition Message", func() {
-	Describe("creating a json payload", func() {
-		limits := types.MessageLimit{
-			ChunkSize:      2000,
-			TotalChunkSize: 6000,
-			ChunkCount:     10,
-		}
-		When("given a message that exceeds the max length", func() {
-			When("not splitting by lines", func() {
-				It("should return a payload with chunked messages", func() {
+	limits := types.MessageLimit{
+		ChunkSize:      2000,
+		TotalChunkSize: 6000,
+		ChunkCount:     10,
+	}
+	When("given a message that exceeds the max length", func() {
+		When("not splitting by lines", func() {
+			It("should return a payload with chunked messages", func() {
 
-					items, _ := testPartitionMessage(42, limits, 100)
+				items, _ := testPartitionMessage(42, limits, 100)
 
-					Expect(len(items[0].Text)).To(Equal(1994))
-					Expect(len(items[1].Text)).To(Equal(1999))
-					Expect(len(items[2].Text)).To(Equal(205))
-				})
-				It("omit characters above total max", func() {
-					items, _ := testPartitionMessage(62, limits, 100)
-
-					Expect(len(items[0].Text)).To(Equal(1994))
-					Expect(len(items[1].Text)).To(Equal(1999))
-					Expect(len(items[2].Text)).To(Equal(1999))
-					Expect(len(items[3].Text)).To(Equal(5))
-				})
+				Expect(len(items[0].Text)).To(Equal(1994))
+				Expect(len(items[1].Text)).To(Equal(1999))
+				Expect(len(items[2].Text)).To(Equal(205))
 			})
-			When("splitting by lines", func() {
-				It("should return a payload with chunked messages", func() {
-					items, omitted := testMessageItemsFromLines(18, limits, 2)
+			It("omit characters above total max", func() {
+				items, _ := testPartitionMessage(62, limits, 100)
 
-					Expect(len(items[0].Text)).To(Equal(200))
-					Expect(len(items[8].Text)).To(Equal(200))
+				Expect(len(items[0].Text)).To(Equal(1994))
+				Expect(len(items[1].Text)).To(Equal(1999))
+				Expect(len(items[2].Text)).To(Equal(1999))
+				Expect(len(items[3].Text)).To(Equal(5))
+			})
+			It("should handle messages with a size modulus of chunksize", func() {
+				items, _ := testPartitionMessage(20, limits, 100)
+				Expect(len(items[0].Text)).To(Equal(1994))
+				Expect(len(items[1].Text)).To(Equal(5))
 
-					Expect(omitted).To(Equal(0))
-				})
-				It("omit characters above total max", func() {
-					items, omitted := testMessageItemsFromLines(19, limits, 2)
+				items, _ = testPartitionMessage(40, limits, 100)
+				Expect(len(items[0].Text)).To(Equal(1994))
+				Expect(len(items[1].Text)).To(Equal(1999))
+				Expect(len(items[2].Text)).To(Equal(5))
+			})
+		})
+		When("splitting by lines", func() {
+			It("should return a payload with chunked messages", func() {
+				items, omitted := testMessageItemsFromLines(18, limits, 2)
 
-					Expect(len(items[0].Text)).To(Equal(200))
-					Expect(len(items[8].Text)).To(Equal(200))
+				Expect(len(items[0].Text)).To(Equal(200))
+				Expect(len(items[8].Text)).To(Equal(200))
 
-					Expect(omitted).To(Equal(100))
-				})
-				It("should trim characters above chunk size", func() {
-					hundreds := 42
-					repeat := 21
-					items, omitted := testMessageItemsFromLines(hundreds, limits, repeat)
+				Expect(omitted).To(Equal(0))
+			})
+			It("omit characters above total max", func() {
+				items, omitted := testMessageItemsFromLines(19, limits, 2)
 
-					Expect(len(items[0].Text)).To(Equal(limits.ChunkSize))
-					Expect(len(items[1].Text)).To(Equal(limits.ChunkSize))
+				Expect(len(items[0].Text)).To(Equal(200))
+				Expect(len(items[8].Text)).To(Equal(200))
 
-					// Trimmed characters do not count towards the total omitted count
-					Expect(omitted).To(Equal(0))
-				})
+				Expect(omitted).To(Equal(100))
+			})
+			It("should trim characters above chunk size", func() {
+				hundreds := 42
+				repeat := 21
+				items, omitted := testMessageItemsFromLines(hundreds, limits, repeat)
 
-				It("omit characters above total chunk size", func() {
-					hundreds := 100
-					repeat := 20
-					items, omitted := testMessageItemsFromLines(hundreds, limits, repeat)
+				Expect(len(items[0].Text)).To(Equal(limits.ChunkSize))
+				Expect(len(items[1].Text)).To(Equal(limits.ChunkSize))
 
-					Expect(len(items[0].Text)).To(Equal(limits.ChunkSize))
-					Expect(len(items[1].Text)).To(Equal(limits.ChunkSize))
-					Expect(len(items[2].Text)).To(Equal(limits.ChunkSize))
+				// Trimmed characters do not count towards the total omitted count
+				Expect(omitted).To(Equal(0))
+			})
 
-					maxRunes := hundreds * 100
-					expectedOmitted := maxRunes - limits.TotalChunkSize
+			It("omit characters above total chunk size", func() {
+				hundreds := 100
+				repeat := 20
+				items, omitted := testMessageItemsFromLines(hundreds, limits, repeat)
 
-					Expect(omitted).To(Equal(expectedOmitted))
-				})
+				Expect(len(items[0].Text)).To(Equal(limits.ChunkSize))
+				Expect(len(items[1].Text)).To(Equal(limits.ChunkSize))
+				Expect(len(items[2].Text)).To(Equal(limits.ChunkSize))
 
+				maxRunes := hundreds * 100
+				expectedOmitted := maxRunes - limits.TotalChunkSize
+
+				Expect(omitted).To(Equal(expectedOmitted))
 			})
 
 		})
+
 	})
 })
 


### PR DESCRIPTION
solves two panic conditions when using the discord service:
 - sending an empty message without a title 
    (fixes #239)
 - sending a message with partitioning and a message that is a modulus of the configured chunk size 
    (fixes #240)
<!--

Thank you for contributing to the shoutrrr project! 🙏

We truly appreciate all the contributions we get from the community.
To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
