### PR TITLE
feat(cli): support reading message from stdin

### DIFF
--- a/internal/util/cobra.go
+++ b/internal/util/cobra.go
@@ -7,19 +7,25 @@ import (
 
 // LoadFlagsFromAltSources is a WORKAROUND to make cobra count env vars and positional arguments when checking required flags
 func LoadFlagsFromAltSources(cmd *cobra.Command, args []string) {
+	flags := cmd.Flags()
 
 	if len(args) > 0 {
-		_ = cmd.Flags().Set("url", args[0])
+		_ = flags.Set("url", args[0])
 
 		if len(args) > 1 {
-			_ = cmd.Flags().Set("message", args[1])
+			_ = flags.Set("message", args[1])
 		}
 
 		return
 	}
 
 	if hasURLInEnvButNotFlag(cmd) {
-		_ = cmd.Flags().Set("url", viper.GetViper().GetString("SHOUTRRR_URL"))
+		_ = flags.Set("url", viper.GetViper().GetString("SHOUTRRR_URL"))
+
+		// If the URL has been set in ENV, default the message to read from stdin
+		if msg, _ := flags.GetString("message"); msg == "" {
+			flags.Set("message", "-")
+		}
 	}
 }
 

--- a/pkg/util/partition_message.go
+++ b/pkg/util/partition_message.go
@@ -53,6 +53,14 @@ func PartitionMessage(input string, limits t.MessageLimit, distance int) (items 
 	return items, len(runes) - chunkOffset
 }
 
+// Ellipsis returns a string that is at most maxLength characters with a ellipsis appended if the input was longer
+func Ellipsis(text string, maxLength int) string {
+	if len(text) > maxLength {
+		text = text[:maxLength-len(ellipsis)] + ellipsis
+	}
+	return text
+}
+
 // MessageItemsFromLines creates a set of MessageItems that is compatible with the supplied limits
 func MessageItemsFromLines(plain string, limits t.MessageLimit) (items []t.MessageItem, omitted int) {
 	omitted = 0

--- a/shoutrrr/cmd/send/send.go
+++ b/shoutrrr/cmd/send/send.go
@@ -31,7 +31,7 @@ func init() {
 	Cmd.Flags().StringArrayP("url", "u", []string{}, "The notification url")
 	_ = Cmd.MarkFlagRequired("url")
 
-	Cmd.Flags().StringP("message", "m", "", "The message to send to the notification url")
+	Cmd.Flags().StringP("message", "m", "", "The message to send to the notification url, or - to read message from stdin")
 	_ = Cmd.MarkFlagRequired("message")
 
 	Cmd.Flags().StringP("title", "t", "", "The title used for services that support it")

--- a/shoutrrr/cmd/send/send.go
+++ b/shoutrrr/cmd/send/send.go
@@ -51,11 +51,13 @@ func run(cmd *cobra.Command) error {
 
 	if message == "-" {
 		logf("Reading from STDIN...")
-		msgBytes, err := io.ReadAll(os.Stdin)
+		sb := strings.Builder{}
+		count, err := io.Copy(&sb, os.Stdin)
 		if err != nil {
 			return fmt.Errorf("failed to read message from stdin: %v", err)
 		}
-		message = string(msgBytes)
+		logf("Read %d byte(s)", count)
+		message = sb.String()
 	}
 
 	var logger *log.Logger


### PR DESCRIPTION
Allows piping the message to shoutrrr CLI:

```
$ some_command | shoutrrr slack://xoxb:123456789012-1234567890123-4mt0t4l1YL3g1T5L4cK70k3N@C0123456789 -
```

When the SHOUTRRR_URL environment variable has been set, you can also just pipe directly to shoutrrr, as the default option is to read from stdin. The main reason not to do this for normal usage is to prevent confusion upon invoking the command without any arguments as it waits for input from the attached console.
```
$ export SHOUTRRR_URL="slack://xoxb:123456789012-1234567890123-4mt0t4l1YL3g1T5L4cK70k3N@C0123456789"
$ some_command | shoutrrr
```

<!--

Thank you for contributing to the shoutrrr project! 🙏

We truly appreciate all the contributions we get from the community.
To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
