### PR TITLE
fix: text partitioning logic

### DIFF
--- a/pkg/util/partition_message.go
+++ b/pkg/util/partition_message.go
@@ -28,8 +28,8 @@ func PartitionMessage(input string, limits t.MessageLimit, distance int) (items 
 		// If no suitable split point is found, start next chunk at chunkSize from chunk start
 		nextChunkStart := chunkOffset + limits.ChunkSize
 		// ... and set the chunk end to the rune before the next chunk
-		chunkEnd := nextChunkStart - 1
-		if chunkEnd > maxTotal {
+		chunkEnd := nextChunkStart
+		if chunkEnd >= maxTotal {
 			// The chunk is smaller than the limit, no need to search
 			chunkEnd = maxTotal
 			nextChunkStart = maxTotal

--- a/pkg/util/partition_message.go
+++ b/pkg/util/partition_message.go
@@ -25,10 +25,10 @@ func PartitionMessage(input string, limits t.MessageLimit, distance int) (items 
 	}
 
 	for i := 0; i < maxCount; i++ {
-		// If no suitable split point is found, start next chunk at chunkSize from chunk start
-		nextChunkStart := chunkOffset + limits.ChunkSize
-		// ... and set the chunk end to the rune before the next chunk
-		chunkEnd := nextChunkStart
+		// If no suitable split point is found, use the chunkSize
+		chunkEnd := chunkOffset + limits.ChunkSize
+		// ... and start next chunk directly after this one
+		nextChunkStart := chunkEnd
 		if chunkEnd >= maxTotal {
 			// The chunk is smaller than the limit, no need to search
 			chunkEnd = maxTotal

--- a/pkg/util/partition_message_test.go
+++ b/pkg/util/partition_message_test.go
@@ -189,11 +189,9 @@ func testPartitionMessage(hundreds int, limits types.MessageLimit, distance int)
 	items, omitted = PartitionMessage(builder.String(), limits, distance)
 
 	contentSize := Min(hundreds*100, limits.TotalChunkSize)
-	// expectedChunkCount := CeilDiv(contentSize, limits.ChunkSize-1)
 	expectedOmitted := Max(0, (hundreds*100)-contentSize)
 
-	ExpectWithOffset(1, omitted).To(Equal(expectedOmitted))
-	// ExpectWithOffset(1, len(items)).To(Equal(expectedChunkCount))
+	ExpectWithOffset(0, omitted).To(Equal(expectedOmitted))
 
 	return
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"io/ioutil"
 	"log"
-	"math"
 )
 
 // Min returns the smallest of a and b
@@ -20,11 +19,6 @@ func Max(a int, b int) int {
 		return a
 	}
 	return b
-}
-
-// CeilDiv returns the quotient from dividing the dividend with the divisor, but rounded up to the nearest integer
-func CeilDiv(dividend int, divisor int) int {
-	return int(math.Ceil(float64(dividend) / float64(divisor)))
 }
 
 // DiscardLogger is a logger that discards any output written to it


### PR DESCRIPTION
The fix in #240 only addressed a specific issue, regarding repeated sequences of strings with no whitespace that were exact multiples of the maximum allow chunk size. It just moved the problem to another offset instead.

This does instead fix the real underlying issue and fixing one oddity with previous implementation (why a text string that were the same length as the chunk size would not fit inside one chunk).

Additionally, this includes a test iterating through 8000 text lengths and verifying the contents as well as the chunk sizes.
The general problem with the test is that the logic for calculating the expected sizes works the same way as the implementation. But matched with the unaligned limits and iteration, it should verify the logic sufficiently.

Fixes #244.
<!--

Thank you for contributing to the shoutrrr project! 🙏

We truly appreciate all the contributions we get from the community.
To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
