### PR TITLE
fix(smtp): use `usestarttls` (match the docs)

### DIFF
--- a/pkg/services/smtp/smtp_config.go
+++ b/pkg/services/smtp/smtp_config.go
@@ -3,9 +3,10 @@ package smtp
 import (
 	"errors"
 	"fmt"
-	"github.com/containrrr/shoutrrr/pkg/util"
 	"net/url"
 	"strconv"
+
+	"github.com/containrrr/shoutrrr/pkg/util"
 
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/types"
@@ -23,7 +24,7 @@ type Config struct {
 	Subject     string    `desc:"The subject of the sent mail" key:"subject,title" default:"Shoutrrr Notification"`
 	Auth        authType  `desc:"SMTP authentication method" key:"auth" default:"Unknown"`
 	Encryption  encMethod `desc:"Encryption method" default:"Auto" key:"encryption"`
-	UseStartTLS bool      `desc:"Whether to use StartTLS encryption" default:"Yes" key:"starttls"`
+	UseStartTLS bool      `desc:"Whether to use StartTLS encryption" default:"Yes" key:"usestarttls"`
 	UseHTML     bool      `desc:"Whether the message being sent is in HTML" default:"No" key:"usehtml"`
 }
 

--- a/pkg/services/smtp/smtp_config.go
+++ b/pkg/services/smtp/smtp_config.go
@@ -6,10 +6,9 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/containrrr/shoutrrr/pkg/util"
-
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/types"
+	"github.com/containrrr/shoutrrr/pkg/util"
 )
 
 // Config is the configuration needed to send e-mail notifications over SMTP
@@ -24,7 +23,7 @@ type Config struct {
 	Subject     string    `desc:"The subject of the sent mail" key:"subject,title" default:"Shoutrrr Notification"`
 	Auth        authType  `desc:"SMTP authentication method" key:"auth" default:"Unknown"`
 	Encryption  encMethod `desc:"Encryption method" default:"Auto" key:"encryption"`
-	UseStartTLS bool      `desc:"Whether to use StartTLS encryption" default:"Yes" key:"usestarttls"`
+	UseStartTLS bool      `desc:"Whether to use StartTLS encryption" default:"Yes" key:"usestarttls,starttls"`
 	UseHTML     bool      `desc:"Whether the message being sent is in HTML" default:"No" key:"usehtml"`
 }
 

--- a/pkg/services/smtp/smtp_test.go
+++ b/pkg/services/smtp/smtp_test.go
@@ -98,9 +98,9 @@ var _ = Describe("the SMTP service", func() {
 			testutils.TestConfigSetInvalidQueryValue(config, "smtp://example.com/?fromAddress=s@example.com&toAddresses=r@example.com&foo=bar")
 		})
 
-		It("should have the exped number of fields and enums", func() {
+		It("should have the expected number of fields and enums", func() {
 			testutils.TestConfigGetEnumsCount(config, 2)
-			testutils.TestConfigGetFieldsCount(config, 11)
+			testutils.TestConfigGetFieldsCount(config, 12)
 		})
 	})
 

--- a/pkg/services/smtp/smtp_test.go
+++ b/pkg/services/smtp/smtp_test.go
@@ -1,6 +1,7 @@
 package smtp
 
 import (
+	"fmt"
 	"log"
 	"net/smtp"
 	"net/url"
@@ -42,9 +43,10 @@ var _ = Describe("the SMTP service", func() {
 	})
 	When("parsing the configuration URL", func() {
 		It("should be identical after de-/serialization", func() {
-			testURL := "smtp://user:password@example.com:2225/?auth=None&encryption=ExplicitTLS&fromaddress=sender%40example.com&fromname=Sender&starttls=No&subject=Subject&toaddresses=rec1%40example.com%2Crec2%40example.com&usehtml=Yes"
+			testURL := "smtp://user:password@example.com:2225/?auth=None&encryption=ExplicitTLS&fromaddress=sender%40example.com&fromname=Sender&subject=Subject&toaddresses=rec1%40example.com%2Crec2%40example.com&usehtml=Yes&usestarttls=No"
 
 			url, err := url.Parse(testURL)
+			fmt.Println(url)
 			Expect(err).NotTo(HaveOccurred(), "parsing")
 
 			config := &Config{}
@@ -53,6 +55,7 @@ var _ = Describe("the SMTP service", func() {
 			Expect(err).NotTo(HaveOccurred(), "verifying")
 
 			outputURL := config.GetURL()
+			fmt.Printf("\n\n%s\n%s\n\n-", outputURL, testURL)
 
 			Expect(outputURL.String()).To(Equal(testURL))
 
@@ -189,7 +192,7 @@ var _ = Describe("the SMTP service", func() {
 		When("given a typical usage case configuration URL", func() {
 
 			It("should send notifications without any errors", func() {
-				testURL := "smtp://user:password@example.com:2225/?startTLS=no&fromAddress=sender@example.com&toAddresses=rec1@example.com,rec2@example.com&useHTML=yes"
+				testURL := "smtp://user:password@example.com:2225/?useStartTLS=no&fromAddress=sender@example.com&toAddresses=rec1@example.com,rec2@example.com&useHTML=yes"
 				err := testIntegration(testURL, []string{
 					"250-mx.google.com at your service",
 					"250-SIZE 35651584",
@@ -217,7 +220,7 @@ var _ = Describe("the SMTP service", func() {
 		When("given a configuration URL with authentication disabled", func() {
 
 			It("should send notifications without any errors", func() {
-				testURL := "smtp://example.com:2225/?startTLS=no&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
+				testURL := "smtp://example.com:2225/?useStartTLS=no&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testIntegration(testURL, []string{
 					"250-mx.google.com at your service",
 					"250-SIZE 35651584",
@@ -240,7 +243,7 @@ var _ = Describe("the SMTP service", func() {
 		When("given a configuration URL with StartTLS but it is not supported", func() {
 
 			It("should send notifications without any errors", func() {
-				testURL := "smtp://example.com:2225/?startTLS=yes&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
+				testURL := "smtp://example.com:2225/?useStartTLS=yes&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testIntegration(testURL, []string{
 					"250-mx.google.com at your service",
 					"250-SIZE 35651584",
@@ -263,7 +266,7 @@ var _ = Describe("the SMTP service", func() {
 		When("server communication fails", func() {
 
 			It("should fail when not being able to enable StartTLS", func() {
-				testURL := "smtp://example.com:2225/?startTLS=yes&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
+				testURL := "smtp://example.com:2225/?useStartTLS=yes&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testIntegration(testURL, []string{
 					"250-mx.google.com at your service",
 					"250-SIZE 35651584",
@@ -281,7 +284,7 @@ var _ = Describe("the SMTP service", func() {
 			})
 
 			It("should fail when authentication type is invalid", func() {
-				testURL := "smtp://example.com:2225/?startTLS=no&auth=bad&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
+				testURL := "smtp://example.com:2225/?useStartTLS=no&auth=bad&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testIntegration(testURL, []string{}, "", "")
 				if msg, test := standard.IsTestSetupFailure(err); test {
 					Skip(msg)
@@ -292,7 +295,7 @@ var _ = Describe("the SMTP service", func() {
 			})
 
 			It("should fail when not being able to use authentication type", func() {
-				testURL := "smtp://example.com:2225/?startTLS=no&auth=crammd5&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
+				testURL := "smtp://example.com:2225/?useStartTLS=no&auth=crammd5&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testIntegration(testURL, []string{
 					"250-mx.google.com at your service",
 					"250-SIZE 35651584",
@@ -309,7 +312,7 @@ var _ = Describe("the SMTP service", func() {
 			})
 
 			It("should fail when not being able to send to recipient", func() {
-				testURL := "smtp://example.com:2225/?startTLS=no&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
+				testURL := "smtp://example.com:2225/?useStartTLS=no&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testIntegration(testURL, []string{
 					"250-mx.google.com at your service",
 					"250-SIZE 35651584",
@@ -326,7 +329,7 @@ var _ = Describe("the SMTP service", func() {
 			})
 
 			It("should fail when the recipient is not accepted", func() {
-				testURL := "smtp://example.com:2225/?startTLS=no&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
+				testURL := "smtp://example.com:2225/?useStartTLS=no&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testSendRecipient(testURL, []string{
 					"250 mx.google.com at your service",
 					"250 Sender OK",
@@ -341,7 +344,7 @@ var _ = Describe("the SMTP service", func() {
 			})
 
 			It("should fail when the server does not accept the data stream", func() {
-				testURL := "smtp://example.com:2225/?startTLS=no&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
+				testURL := "smtp://example.com:2225/?useStartTLS=no&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testSendRecipient(testURL, []string{
 					"250 mx.google.com at your service",
 					"250 Sender OK",
@@ -357,7 +360,7 @@ var _ = Describe("the SMTP service", func() {
 			})
 
 			It("should fail when the server does not accept the data stream content", func() {
-				testURL := "smtp://example.com:2225/?startTLS=no&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
+				testURL := "smtp://example.com:2225/?useStartTLS=no&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testSendRecipient(testURL, []string{
 					"250 mx.google.com at your service",
 					"250 Sender OK",
@@ -374,7 +377,7 @@ var _ = Describe("the SMTP service", func() {
 			})
 
 			It("should fail when the server does not close the connection gracefully", func() {
-				testURL := "smtp://example.com:2225/?startTLS=no&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
+				testURL := "smtp://example.com:2225/?useStartTLS=no&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testIntegration(testURL, []string{
 					"250-mx.google.com at your service",
 					"250-SIZE 35651584",


### PR DESCRIPTION
The [smtp docs](https://containrrr.dev/shoutrrr/v0.5/services/smtp/config/#queryparam_props) mention `UseStartTLS`, but it doesn't accept `usestarttls`, it wants `starttls`. As `UseStartTLS` is the Go var, it was probably designed to be `usestarttls` as the key, so here's a PR for that.

Thanks to @samcro1967 for spotting this in the issue for my PR that added Shoutrrr
https://github.com/release-argus/Argus/issues/33#issuecomment-1139113316

Wasn't sure about how/whether you'd want to keep support for `starttls` for a while as it would show in the docs if I put it under keys, right?