### PR TITLE
feat(generic): add builtin JSON tpl

### DIFF
--- a/docs/services/generic.md
+++ b/docs/services/generic.md
@@ -1,8 +1,20 @@
 # Generic
 The Generic service can be used for any target that is not explicitly supported by Shoutrrr, as long as it
-supports recieving the message via a POST request.
-Usually, this requires customization on the recieving end to interpret the payload that it recives, and might
+supports receiving the message via a POST request.
+Usually, this requires customization on the receiving end to interpret the payload that it receives, and might
 not be a viable approach.
+
+## JSON template
+By using the built in `JSON` template (`template=json`) you can create a generic JSON payload. The keys used for `title` and `message` can be overriden
+by supplying the params/query values `titleKey` and `messageKey`.
+
+!!! example
+    ```json
+    {
+        "title": "Oh no!",
+        "message": "The thing happened and now there is stuff all over the area!"
+    }
+    ```
 
 ## Shortcut URL
 You can just add `generic+` as a prefix to your target URL to use it with the generic service, so

--- a/internal/meta/version.go
+++ b/internal/meta/version.go
@@ -1,7 +1,7 @@
 package meta
 
 // Version of Shoutrrr
-const Version = `0.5-dev`
+const Version = `0.6-dev`
 
 // DocsVersion is prepended to documentation URLs and usually equals MAJOR.MINOR of Version
 const DocsVersion = `dev`

--- a/pkg/services/generic/generic.go
+++ b/pkg/services/generic/generic.go
@@ -2,6 +2,7 @@ package generic
 
 import (
 	"encoding/json"
+	"io/ioutil"
 
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
@@ -79,8 +80,15 @@ func (service *Service) doSend(config *Config, params types.Params) error {
 	req, err := http.NewRequest(config.RequestMethod, postURL, payload)
 	if err == nil {
 		req.Header.Set("Content-Type", config.ContentType)
+		req.Header.Set("Accept", config.ContentType)
 		var res *http.Response
 		res, err = http.DefaultClient.Do(req)
+		if res != nil && res.Body != nil {
+			defer res.Body.Close()
+			if body, errRead := ioutil.ReadAll(res.Body); errRead == nil {
+				service.Log("Server response: ", string(body))
+			}
+		}
 		if err == nil && res.StatusCode >= http.StatusMultipleChoices {
 			err = fmt.Errorf("server returned response status code %s", res.Status)
 		}

--- a/pkg/services/generic/generic.go
+++ b/pkg/services/generic/generic.go
@@ -1,11 +1,14 @@
 package generic
 
 import (
-	"bytes"
-	"fmt"
+	"encoding/json"
+
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	"github.com/containrrr/shoutrrr/pkg/types"
+
+	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -20,14 +23,23 @@ type Service struct {
 }
 
 // Send a notification message to a generic webhook endpoint
-func (service *Service) Send(message string, params *types.Params) error {
-	config := service.config
+func (service *Service) Send(message string, paramsPtr *types.Params) error {
+	config := *service.config
 
-	if err := service.pkr.UpdateConfigFromParams(config, params); err != nil {
+	var params types.Params
+	if paramsPtr == nil {
+		params = types.Params{}
+	} else {
+		params = *paramsPtr
+	}
+
+	if err := service.pkr.UpdateConfigFromParams(&config, &params); err != nil {
 		service.Logf("Failed to update params: %v", err)
 	}
 
-	if err := service.doSend(config, message, params); err != nil {
+	updateParams(&config, params, message)
+
+	if err := service.doSend(&config, params); err != nil {
 		return fmt.Errorf("an error occurred while sending notification to generic webhook: %s", err.Error())
 	}
 
@@ -57,35 +69,53 @@ func (*Service) GetConfigURLFromCustom(customURL *url.URL) (serviceURL *url.URL,
 	return config.getURL(&pkr), nil
 }
 
-func (service *Service) doSend(config *Config, message string, params *types.Params) error {
+func (service *Service) doSend(config *Config, params types.Params) error {
 	postURL := config.WebhookURL().String()
-	payload, err := service.getPayload(config.Template, message, params)
+	payload, err := service.getPayload(config, params)
 	if err != nil {
 		return err
 	}
 
-	res, err := http.Post(postURL, config.ContentType, payload)
-	if err == nil && res.StatusCode != http.StatusOK {
-		err = fmt.Errorf("server returned response status code %s", res.Status)
+	req, err := http.NewRequest(config.RequestMethod, postURL, payload)
+	if err == nil {
+		req.Header.Set("Content-Type", config.ContentType)
+		var res *http.Response
+		res, err = http.DefaultClient.Do(req)
+		if err == nil && res.StatusCode >= http.StatusMultipleChoices {
+			err = fmt.Errorf("server returned response status code %s", res.Status)
+		}
 	}
 
 	return err
 }
 
-func (service *Service) getPayload(template string, message string, params *types.Params) (io.Reader, error) {
-	if template == "" {
-		return bytes.NewBufferString(message), nil
+func (service *Service) getPayload(config *Config, params types.Params) (io.Reader, error) {
+	switch config.Template {
+	case "":
+		return bytes.NewBufferString(params[config.MessageKey]), nil
+	case "json", "JSON":
+		jsonBytes, err := json.Marshal(params)
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewBuffer(jsonBytes), nil
 	}
-	tpl, found := service.GetTemplate(template)
+	tpl, found := service.GetTemplate(config.Template)
 	if !found {
-		return nil, fmt.Errorf("template %q has not been loaded", template)
+		return nil, fmt.Errorf("template %q has not been loaded", config.Template)
 	}
 
-	if params == nil {
-		params = &types.Params{}
-	}
-	params.SetMessage(message)
 	bb := &bytes.Buffer{}
 	err := tpl.Execute(bb, params)
 	return bb, err
+}
+
+func updateParams(config *Config, params types.Params, message string) {
+	if title, found := params.Title(); found {
+		if config.TitleKey != "title" {
+			delete(params, "title")
+			params[config.TitleKey] = title
+		}
+	}
+	params[config.MessageKey] = message
 }

--- a/pkg/services/generic/generic_config.go
+++ b/pkg/services/generic/generic_config.go
@@ -1,20 +1,24 @@
 package generic
 
 import (
+	"net/url"
+
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	t "github.com/containrrr/shoutrrr/pkg/types"
-	"net/url"
 )
 
 // Config for use within the generic service
 type Config struct {
 	standard.EnumlessConfig
-	webhookURL  *url.URL
-	ContentType string `key:"contenttype" default:"application/json" desc:"The value of the Content-Type header"`
-	DisableTLS  bool   `key:"disabletls" default:"No"`
-	Template    string `key:"template" optional:""`
-	Title       string `key:"title" default:""`
+	webhookURL    *url.URL
+	ContentType   string `key:"contenttype" default:"application/json" desc:"The value of the Content-Type header"`
+	DisableTLS    bool   `key:"disabletls"  default:"No"`
+	Template      string `key:"template"    optional:"" desc:"The template used for creating the request payload"`
+	Title         string `key:"title"       default:""`
+	TitleKey      string `key:"titlekey"    default:"title" desc:"The key that will be used for the title value"`
+	MessageKey    string `key:"messagekey"  default:"message" desc:"The key that will be used for the message value"`
+	RequestMethod string `key:"method"      default:"POST"`
 }
 
 // DefaultConfig creates a PropKeyResolver and uses it to populate the default values of a new Config, returning both


### PR DESCRIPTION
This adds some additional functionality to the `generic` service to make it a bit more useful.

You can now supply the template as `json` to format the `message` and `title` as a simple JSON-object. Combined with the ability to rename the keys in the payload, it should add compatibility with at least a few know services.

ref #256 

<!--

Thank you for contributing to the shoutrrr project! 🙏

We truly appreciate all the contributions we get from the community.
To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
