### PR TITLE
feat(smtp): add support for custom client host

### DIFF
--- a/internal/testutils/textconfaker.go
+++ b/internal/testutils/textconfaker.go
@@ -41,6 +41,11 @@ func (tcf *textConFaker) GetConversation(includeGreeting bool) string {
 		if len(tcf.responses) > ri && !inSequence {
 			resp = tcf.responses[ri]
 		}
+
+		if query == "" && resp == "" && i == len(input)-1 {
+			break
+		}
+
 		conv += fmt.Sprintf("  #%2d >> %50s << %-50s\n", i, query, resp)
 		for len(resp) > 3 && resp[3] == '-' {
 			ri++

--- a/pkg/services/smtp/smtp.go
+++ b/pkg/services/smtp/smtp.go
@@ -65,7 +65,7 @@ func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) e
 
 // Send a notification message to e-mail recipients
 func (service *Service) Send(message string, params *types.Params) error {
-	client, err := service.getClientConnection(service.config)
+	client, err := getClientConnection(service.config)
 	if err != nil {
 		return fail(FailGetSMTPClient, err)
 	}
@@ -78,7 +78,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 	return service.doSend(client, message, &config)
 }
 
-func (service *Service) getClientConnection(config *Config) (*smtp.Client, error) {
+func getClientConnection(config *Config) (*smtp.Client, error) {
 
 	var conn net.Conn
 	var err error
@@ -271,7 +271,7 @@ func (service *Service) writeMessagePart(wc io.WriteCloser, message string, temp
 			return fail(FailMessageTemplate, err)
 		}
 	} else {
-		if _, err := fmt.Fprintf(wc, message); err != nil {
+		if _, err := fmt.Fprint(wc, message); err != nil {
 			return fail(FailMessageRaw, err)
 		}
 	}

--- a/pkg/services/smtp/smtp.go
+++ b/pkg/services/smtp/smtp.go
@@ -161,12 +161,13 @@ func (service *Service) resolveClientHost(config *Config) string {
 		return config.ClientHost
 	}
 
-	if hostname, err := os.Hostname(); err == nil {
-		return hostname
-	} else {
+	hostname, err := os.Hostname()
+	if err != nil {
 		service.Logf("Failed to get hostname, falling back to localhost: %v", err)
 		return "localhost"
 	}
+
+	return hostname
 }
 
 func (service *Service) getAuth(config *Config) (smtp.Auth, failure) {

--- a/pkg/services/smtp/smtp_config.go
+++ b/pkg/services/smtp/smtp_config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Encryption  encMethod `desc:"Encryption method" default:"Auto" key:"encryption"`
 	UseStartTLS bool      `desc:"Whether to use StartTLS encryption" default:"Yes" key:"usestarttls,starttls"`
 	UseHTML     bool      `desc:"Whether the message being sent is in HTML" default:"No" key:"usehtml"`
+	ClientHost  string    `desc:"The client host name sent to the SMTP server during HELLO phase. If set to \"auto\" it will use the OS hostname" key:"clienthost" default:"localhost"`
 }
 
 // GetURL returns a URL representation of it's current field values

--- a/pkg/services/smtp/smtp_failures.go
+++ b/pkg/services/smtp/smtp_failures.go
@@ -43,35 +43,56 @@ const (
 	FailCreateSMTPClient
 	// FailApplySendParams is returned when updating the send config failed
 	FailApplySendParams
+	// FailHandshake is returned when the initial HELLO handshake returned an error
+	FailHandshake
 )
 
 func fail(failureID failures.FailureID, err error, v ...interface{}) failure {
-	messages := map[int]string{
-		int(FailGetSMTPClient):    "error getting SMTP client",
-		int(FailConnectToServer):  "error connecting to server",
-		int(FailCreateSMTPClient): "error creating smtp client",
-		int(FailEnableStartTLS):   "error enabling StartTLS",
-		int(FailAuthenticating):   "error authenticating",
-		int(FailAuthType):         "invalid authorization method '%s'",
-		int(FailSendRecipient):    "error sending message to recipient",
-		int(FailClosingSession):   "error closing session",
-		int(FailPlainHeader):      "error writing plain header",
-		int(FailHTMLHeader):       "error writing HTML header",
-		int(FailMultiEndHeader):   "error writing multipart end header",
-		int(FailMessageTemplate):  "error applying message template",
-		int(FailMessageRaw):       "error writing message",
-		int(FailSetSender):        "error creating new message",
-		int(FailSetRecipient):     "error setting RCPT",
-		int(FailOpenDataStream):   "error creating message stream",
-		int(FailWriteHeaders):     "error writing message headers",
-		int(FailCloseDataStream):  "error closing message stream",
-		int(FailApplySendParams):  "error applying params to send config",
-		int(FailUnknown):          "an unknown error occurred",
-	}
-
-	msg := messages[int(failureID)]
-	if msg == "" {
-		msg = messages[int(FailUnknown)]
+	var msg string
+	switch failureID {
+	case FailGetSMTPClient:
+		msg = "error getting SMTP client"
+	case FailConnectToServer:
+		msg = "error connecting to server"
+	case FailCreateSMTPClient:
+		msg = "error creating smtp client"
+	case FailEnableStartTLS:
+		msg = "error enabling StartTLS"
+	case FailAuthenticating:
+		msg = "error authenticating"
+	case FailAuthType:
+		msg = "invalid authorization method '%s'"
+	case FailSendRecipient:
+		msg = "error sending message to recipient"
+	case FailClosingSession:
+		msg = "error closing session"
+	case FailPlainHeader:
+		msg = "error writing plain header"
+	case FailHTMLHeader:
+		msg = "error writing HTML header"
+	case FailMultiEndHeader:
+		msg = "error writing multipart end header"
+	case FailMessageTemplate:
+		msg = "error applying message template"
+	case FailMessageRaw:
+		msg = "error writing message"
+	case FailSetSender:
+		msg = "error creating new message"
+	case FailSetRecipient:
+		msg = "error setting RCPT"
+	case FailOpenDataStream:
+		msg = "error creating message stream"
+	case FailWriteHeaders:
+		msg = "error writing message headers"
+	case FailCloseDataStream:
+		msg = "error closing message stream"
+	case FailApplySendParams:
+		msg = "error applying params to send config"
+	case FailHandshake:
+		msg = "server did not accept the handshake"
+	default:
+	case FailUnknown:
+		msg = "an unknown error occurred"
 	}
 
 	return failures.Wrap(msg, failureID, err, v...)

--- a/pkg/services/smtp/smtp_failures.go
+++ b/pkg/services/smtp/smtp_failures.go
@@ -90,8 +90,8 @@ func fail(failureID failures.FailureID, err error, v ...interface{}) failure {
 		msg = "error applying params to send config"
 	case FailHandshake:
 		msg = "server did not accept the handshake"
+	// case FailUnknown:
 	default:
-	case FailUnknown:
 		msg = "an unknown error occurred"
 	}
 

--- a/pkg/services/smtp/smtp_test.go
+++ b/pkg/services/smtp/smtp_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 
+	gt "github.com/onsi/gomega/types"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -43,7 +45,7 @@ var _ = Describe("the SMTP service", func() {
 	})
 	When("parsing the configuration URL", func() {
 		It("should be identical after de-/serialization", func() {
-			testURL := "smtp://user:password@example.com:2225/?auth=None&encryption=ExplicitTLS&fromaddress=sender%40example.com&fromname=Sender&subject=Subject&toaddresses=rec1%40example.com%2Crec2%40example.com&usehtml=Yes&usestarttls=No"
+			testURL := "smtp://user:password@example.com:2225/?auth=None&clienthost=testhost&encryption=ExplicitTLS&fromaddress=sender%40example.com&fromname=Sender&subject=Subject&toaddresses=rec1%40example.com%2Crec2%40example.com&usehtml=Yes&usestarttls=No"
 
 			url, err := url.Parse(testURL)
 			fmt.Println(url)
@@ -100,7 +102,7 @@ var _ = Describe("the SMTP service", func() {
 
 		It("should have the expected number of fields and enums", func() {
 			testutils.TestConfigGetEnumsCount(config, 2)
-			testutils.TestConfigGetFieldsCount(config, 12)
+			testutils.TestConfigGetFieldsCount(config, 13)
 		})
 	})
 
@@ -265,6 +267,18 @@ var _ = Describe("the SMTP service", func() {
 
 		When("server communication fails", func() {
 
+			It("should fail when initial handshake is not accepted", func() {
+				testURL := "smtp://example.com:2225/?useStartTLS=yes&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no&clienthost=spammer"
+				err := testIntegration(testURL, []string{
+					"421 4.7.0 Try again later, closing connection. (EHLO) r20-20020a50d694000000b004588af8956dsm771862edi.9 - gsmtp",
+				}, "", "")
+				if msg, test := standard.IsTestSetupFailure(err); test {
+					Skip(msg)
+					return
+				}
+				Expect(err).To(MatchError(fail(FailHandshake, nil)))
+			})
+
 			It("should fail when not being able to enable StartTLS", func() {
 				testURL := "smtp://example.com:2225/?useStartTLS=yes&auth=none&fromAddress=sender@example.com&toAddresses=rec1@example.com&useHTML=no"
 				err := testIntegration(testURL, []string{
@@ -279,8 +293,7 @@ var _ = Describe("the SMTP service", func() {
 					Skip(msg)
 					return
 				}
-				Expect(err).To(HaveOccurred())
-				Expect(err.ID()).To(Equal(FailEnableStartTLS))
+				Expect(err).To(matchFailure(FailEnableStartTLS))
 			})
 
 			It("should fail when authentication type is invalid", func() {
@@ -290,8 +303,7 @@ var _ = Describe("the SMTP service", func() {
 					Skip(msg)
 					return
 				}
-				Expect(err).To(HaveOccurred())
-				Expect(err.ID()).To(Equal(standard.FailServiceInit))
+				Expect(err).To(matchFailure(standard.FailServiceInit))
 			})
 
 			It("should fail when not being able to use authentication type", func() {
@@ -307,8 +319,7 @@ var _ = Describe("the SMTP service", func() {
 					Skip(msg)
 					return
 				}
-				Expect(err).To(HaveOccurred())
-				Expect(err.ID()).To(Equal(FailAuthenticating))
+				Expect(err).To(matchFailure(FailAuthenticating))
 			})
 
 			It("should fail when not being able to send to recipient", func() {
@@ -324,8 +335,7 @@ var _ = Describe("the SMTP service", func() {
 					Skip(msg)
 					return
 				}
-				Expect(err).To(HaveOccurred())
-				Expect(err.ID()).To(Equal(FailSendRecipient))
+				Expect(err).To(matchFailure(FailSendRecipient))
 			})
 
 			It("should fail when the recipient is not accepted", func() {
@@ -339,8 +349,7 @@ var _ = Describe("the SMTP service", func() {
 					Skip(msg)
 					return
 				}
-				Expect(err).To(HaveOccurred())
-				Expect(err.ID()).To(Equal(FailSetRecipient))
+				Expect(err).To(matchFailure(FailSetRecipient))
 			})
 
 			It("should fail when the server does not accept the data stream", func() {
@@ -355,8 +364,7 @@ var _ = Describe("the SMTP service", func() {
 					Skip(msg)
 					return
 				}
-				Expect(err).To(HaveOccurred())
-				Expect(err.ID()).To(Equal(FailOpenDataStream))
+				Expect(err).To(matchFailure(FailOpenDataStream))
 			})
 
 			It("should fail when the server does not accept the data stream content", func() {
@@ -372,8 +380,7 @@ var _ = Describe("the SMTP service", func() {
 					Skip(msg)
 					return
 				}
-				Expect(err).To(HaveOccurred())
-				Expect(err.ID()).To(Equal(FailCloseDataStream))
+				Expect(err).To(matchFailure(FailCloseDataStream))
 			})
 
 			It("should fail when the server does not close the connection gracefully", func() {
@@ -394,7 +401,7 @@ var _ = Describe("the SMTP service", func() {
 					return
 				}
 				Expect(err).To(HaveOccurred())
-				Expect(err.ID()).To(Equal(FailClosingSession))
+				Expect(err).To(matchFailure(FailClosingSession))
 			})
 
 		})
@@ -492,4 +499,9 @@ func fakeTLSEnabled(client *smtp.Client, hostname string) {
 	cr = reflect.ValueOf(client).Elem().FieldByName("serverName")
 	cr = reflect.NewAt(cr.Type(), unsafe.Pointer(cr.UnsafeAddr())).Elem()
 	cr.SetString(hostname)
+}
+
+// matchFailure is a simple wrapper around `fail` and `gomega.MatchError`` to make it easier to use in tests
+func matchFailure(id failures.FailureID) gt.GomegaMatcher {
+	return MatchError(fail(id, nil))
 }


### PR DESCRIPTION
Adds the `clienthost` property that can be used to send a specific host name during the initial `HELO/EHLO` greeting phase. It can also be set to `auto` to use the OS hostname as the client host name.

Solves connections to `smtp-relay.gmail.com` which soft-requires the name to be non-generic:
[support.google.com/a/answer/2956491](https://support.google.com/a/answer/2956491?hl=en#:~:text=We%20recommend%20that%20servers%20presents%20unique%20identifiers%20in%20the%20HELO%20or%20EHLO%20arguments%20during%20SMTP%20connections.%20For%20example%2C%20use%20your%20domain%20name%20or%20the%20server%20name%2C%20instead%20of%20generic%20identifiers%20such%20as%20localhost%20or%20smtp%2Drelay.gmail.com.)

This will also handle and log when the initial response from the server isn't valid, giving a better error message in these cases.

Fixes #270 