### PR TITLE
feat: wrap errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containrrr/shoutrrr
 
-go 1.12
+go 1.13
 
 require (
 	github.com/fatih/color v1.10.0

--- a/pkg/services/bark/bark.go
+++ b/pkg/services/bark/bark.go
@@ -28,7 +28,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 	}
 
 	if err := service.sendAPI(config, message); err != nil {
-		return fmt.Errorf("failed to send bark notification: %v", err)
+		return fmt.Errorf("failed to send bark notification: %w", err)
 	}
 
 	return nil

--- a/pkg/services/discord/discord_test.go
+++ b/pkg/services/discord/discord_test.go
@@ -215,7 +215,7 @@ var _ = Describe("the discord service", func() {
 			httpmock.Activate()
 			service = Service{}
 			if err := service.Initialize(dummyConfig.GetURL(), logger); err != nil {
-				panic(fmt.Errorf("service initialization failed: %v", err))
+				panic(fmt.Errorf("service initialization failed: %w", err))
 			}
 		})
 		AfterEach(func() {

--- a/pkg/services/matrix/matrix.go
+++ b/pkg/services/matrix/matrix.go
@@ -49,7 +49,7 @@ func (s *Service) Send(message string, params *t.Params) error {
 
 	if len(errors) > 0 {
 		for _, err := range errors {
-			s.Logf("error sending message: %v", err)
+			s.Logf("error sending message: %w", err)
 		}
 		return fmt.Errorf("%v error(s) sending message, with initial error: %v", len(errors), errors[0])
 	}

--- a/pkg/services/matrix/matrix_client.go
+++ b/pkg/services/matrix/matrix_client.go
@@ -52,7 +52,7 @@ func (c *client) login(user string, password string) error {
 
 	resLogin := apiResLoginFlows{}
 	if err := c.apiGet(apiLogin, &resLogin); err != nil {
-		return fmt.Errorf("failed to get login flows: %v", err)
+		return fmt.Errorf("failed to get login flows: %w", err)
 	}
 
 	var flows []string
@@ -68,14 +68,13 @@ func (c *client) login(user string, password string) error {
 }
 
 func (c *client) loginPassword(user string, password string) error {
-
 	response := apiResLogin{}
 	if err := c.apiPost(apiLogin, apiReqLogin{
 		Type:       flowLoginPassword,
 		Password:   password,
 		Identifier: newUserIdentifier(user),
 	}, &response); err != nil {
-		return fmt.Errorf("failed to log in: %v", err)
+		return fmt.Errorf("failed to log in: %w", err)
 	}
 
 	c.accessToken = response.AccessToken
@@ -106,7 +105,7 @@ func (c *client) sendToExplicitRooms(rooms []string, message string) (errors []e
 
 		var roomID string
 		if roomID, err = c.joinRoom(room); err != nil {
-			errors = append(errors, fmt.Errorf("error joining room %v: %v", roomID, err))
+			errors = append(errors, fmt.Errorf("error joining room %v: %w", roomID, err))
 			continue
 		}
 
@@ -115,7 +114,7 @@ func (c *client) sendToExplicitRooms(rooms []string, message string) (errors []e
 		}
 
 		if err := c.sendMessageToRoom(message, roomID); err != nil {
-			errors = append(errors, fmt.Errorf("failed to send message to room '%v': %v", roomID, err))
+			errors = append(errors, fmt.Errorf("failed to send message to room '%v': %w", roomID, err))
 		}
 	}
 
@@ -125,14 +124,14 @@ func (c *client) sendToExplicitRooms(rooms []string, message string) (errors []e
 func (c *client) sendToJoinedRooms(message string) (errors []error) {
 	joinedRooms, err := c.getJoinedRooms()
 	if err != nil {
-		return append(errors, fmt.Errorf("failed to get joined rooms: %v", err))
+		return append(errors, fmt.Errorf("failed to get joined rooms: %w", err))
 	}
 
 	// Send to all rooms that are joined
 	for _, roomID := range joinedRooms {
 		c.logf("Sending message to '%v'...\n", roomID)
 		if err := c.sendMessageToRoom(message, roomID); err != nil {
-			errors = append(errors, fmt.Errorf("failed to send message to room '%v': %v", roomID, err))
+			errors = append(errors, fmt.Errorf("failed to send message to room '%v': %w", roomID, err))
 		}
 	}
 

--- a/pkg/services/pushbullet/pushbullet.go
+++ b/pkg/services/pushbullet/pushbullet.go
@@ -63,7 +63,7 @@ func doSend(config *Config, target string, message string, client jsonclient.Cli
 		if client.ErrorResponse(err, &errorResponse) {
 			return fmt.Errorf("API error: %v", errorResponse.Error.Message)
 		}
-		return fmt.Errorf("failed to push: %v", err)
+		return fmt.Errorf("failed to push: %w", err)
 	}
 
 	// TODO: Look at response fields?

--- a/pkg/services/pushbullet/pushbullet.go
+++ b/pkg/services/pushbullet/pushbullet.go
@@ -59,9 +59,9 @@ func doSend(config *Config, target string, message string, client jsonclient.Cli
 
 	response := PushResponse{}
 	if err := client.Post(pushesEndpoint, push, &response); err != nil {
-		errorResponse := ErrorResponse{}
-		if client.ErrorResponse(err, &errorResponse) {
-			return fmt.Errorf("API error: %v", errorResponse.Error.Message)
+		errorResponse := &ErrorResponse{}
+		if client.ErrorResponse(err, errorResponse) {
+			return fmt.Errorf("API error: %w", errorResponse)
 		}
 		return fmt.Errorf("failed to push: %w", err)
 	}

--- a/pkg/services/pushbullet/pushbullet_json.go
+++ b/pkg/services/pushbullet/pushbullet_json.go
@@ -35,7 +35,7 @@ type PushResponse struct {
 }
 
 type ErrorResponse struct {
-	Error struct {
+	ErrorData struct {
 		Cat     string `json:"cat"`
 		Message string `json:"message"`
 		Type    string `json:"type"`
@@ -43,6 +43,10 @@ type ErrorResponse struct {
 }
 
 var emailPattern = regexp.MustCompile(`.*@.*\..*`)
+
+func (err *ErrorResponse) Error() string {
+	return err.ErrorData.Message
+}
 
 func (p *PushRequest) SetTarget(target string) {
 	if emailPattern.MatchString(target) {

--- a/pkg/services/pushover/pushover.go
+++ b/pkg/services/pushover/pushover.go
@@ -33,7 +33,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 
 	device := strings.Join(config.Devices, ",")
 	if err := service.sendToDevice(device, message, config); err != nil {
-		return fmt.Errorf("failed to send notifications to pushover devices: %v", err)
+		return fmt.Errorf("failed to send notifications to pushover devices: %w", err)
 	}
 
 	return nil

--- a/pkg/services/rocketchat/rocketchat.go
+++ b/pkg/services/rocketchat/rocketchat.go
@@ -37,7 +37,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 	json, _ := CreateJSONPayload(config, message, params)
 	res, err = http.Post(apiURL, "application/json", bytes.NewReader(json))
 	if err != nil {
-		return fmt.Errorf("Error while posting to URL: %v\nHOST: %s\nPORT: %s", err, config.Host, config.Port)
+		return fmt.Errorf("Error while posting to URL: %w\nHOST: %s\nPORT: %s", err, config.Host, config.Port)
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {

--- a/pkg/services/slack/slack.go
+++ b/pkg/services/slack/slack.go
@@ -43,7 +43,7 @@ func (service *Service) Send(message string, params *types.Params) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to send slack notification: %v", err)
+		return fmt.Errorf("failed to send slack notification: %w", err)
 	}
 
 	return nil
@@ -88,7 +88,7 @@ func (service *Service) sendWebhook(config *Config, payload interface{}) error {
 	res, err = http.Post(config.Token.WebhookURL(), jsonclient.ContentType, bytes.NewBuffer(payloadBytes))
 
 	if err != nil {
-		return fmt.Errorf("failed to invoke webhook: %v", err)
+		return fmt.Errorf("failed to invoke webhook: %w", err)
 	}
 	defer res.Body.Close()
 	resBytes, _ := ioutil.ReadAll(res.Body)

--- a/pkg/services/teams/teams_config.go
+++ b/pkg/services/teams/teams_config.go
@@ -93,7 +93,7 @@ func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) e
 	}
 
 	if err := verifyWebhookParts(webhookParts); err != nil {
-		return fmt.Errorf("invalid URL format: %v", err)
+		return fmt.Errorf("invalid URL format: %w", err)
 	}
 
 	config.setFromWebhookParts(webhookParts)

--- a/pkg/util/jsonclient/jsonclient.go
+++ b/pkg/util/jsonclient/jsonclient.go
@@ -68,12 +68,12 @@ func (c *client) Post(url string, request interface{}, response interface{}) err
 
 	body, err = json.MarshalIndent(request, "", c.indent)
 	if err != nil {
-		return fmt.Errorf("error creating payload: %v", err)
+		return fmt.Errorf("error creating payload: %w", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("error creating request: %v", err)
+		return fmt.Errorf("error creating request: %w", err)
 	}
 
 	for key, val := range c.headers {
@@ -83,7 +83,7 @@ func (c *client) Post(url string, request interface{}, response interface{}) err
 	var res *http.Response
 	res, err = c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("error sending payload: %v", err)
+		return fmt.Errorf("error sending payload: %w", err)
 	}
 
 	return parseResponse(res, response)

--- a/shoutrrr/cmd/send/send.go
+++ b/shoutrrr/cmd/send/send.go
@@ -54,7 +54,7 @@ func run(cmd *cobra.Command) error {
 		sb := strings.Builder{}
 		count, err := io.Copy(&sb, os.Stdin)
 		if err != nil {
-			return fmt.Errorf("failed to read message from stdin: %v", err)
+			return fmt.Errorf("failed to read message from stdin: %w", err)
 		}
 		logf("Read %d byte(s)", count)
 		message = sb.String()


### PR DESCRIPTION
In #143 we briefly discussed parsing error messages and whether wrapping errors could help with that.

This is a somewhat simple change to do that. We could probably do more by rewriting stuff to get more and better error messages.

This change tries to stay backward compatible. But notice:

- We bump the required go to version 1.13 because we cannot wrap error in earlier versions. 1.12 is a long time ago, so I hope this will be fine.
- Refactor the Pushbullet implementations `ErrorResponse` to implement an error interface. This requires renaming an exported field. I cannot really see how anyone could use the exported field, though, so I think this is safe to do.