### PR TITLE
Cleanup and improve GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: monthly
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: monthly

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ on:
       - main
       - latest
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Documentation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - 'docs/*'
 
+permissions:
+  contents: read
+
 jobs:
   go-versions:
     name: Lookup go versions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,6 @@ jobs:
         run: CGO_ENABLED=0 go test -v -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Publish coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,18 +12,32 @@ on:
       - 'docs/*'
 
 jobs:
+  go-versions:
+    name: Lookup go versions
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.versions.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: arnested/go-version-action@v1
+        id: versions
   build:
     name: Build Shoutrrr
     runs-on: ubuntu-latest
+    needs: go-versions
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
     steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+      - name: Set up Go ${{ matrix.version }}
+        uses: actions/setup-go@v3
         id: go
         with:
-          go-version: 1.13
+          go-version: ${{ matrix.version }}
+          check-latest: true
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Build
         run: CGO_ENABLED=0 go build -v .

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -6,6 +6,8 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - '**/v[0-9]+.[0-9]+.[0-9]+'
 
+permissions: {}
+
 jobs:
   build:
     name: Renew documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Shoutrrr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: CGO_ENABLED=0 go test -v -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Publish coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,18 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - uses: arnested/go-version-action@v1
+        id: go-version
+
+      - name: Set up Go ${{ steps.go-version.outputs.latest }}
+        uses: actions/setup-go@v3
         id: go
         with:
-          go-version: 1.13
-
-      - name: Check out code
-        uses: actions/checkout@v1
+          go-version: ${{ steps.go-version.outputs.latest }}
+          check-latest: true
 
       - name: Build
         run: CGO_ENABLED=0 go build -v .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,13 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Install goreleaser
-        run: |
-          cd .. && \
-          wget https://github.com/goreleaser/goreleaser/releases/download/v0.138.0/goreleaser_Linux_x86_64.tar.gz && \
-          tar -xvf goreleaser_Linux_x86_64.tar.gz && \
-          ./goreleaser -v
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          install-only: true
+
+      - name: Show GoReleaser version
+        run: goreleaser -v
 
       - name: Login to docker hub
         uses: azure/docker-login@v1
@@ -51,7 +52,7 @@ jobs:
 
       - name: Execute goreleaser
         run: |
-          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} CGO_ENABLED=0 ../goreleaser --debug --rm-dist
+          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} CGO_ENABLED=0 goreleaser --debug --rm-dist
 
       - name: Enable experimental docker features
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containrrr/shoutrrr
 
-go 1.12
+go 1.13
 
 require (
 	github.com/fatih/color v1.10.0


### PR DESCRIPTION
### Use build matrix of go versions

GitHub Actions only tested the build using go 1.13 (which has been unsupported by the Go team for more than two years).

Introduce a build matrix testing all versions from the lowest supported by shoutrrr to the newest released by the Go team (shamelessly using my own [Go Version Action](https://github.com/marketplace/actions/go-version-action)).

### Bump required go to 1.13 in `go.mod`

The matrix test showed the code didn't compile in go1.12 anymore. 

### Build release using latest Go version

The release action built the version for release with go 1.13. From now, we'll use the latest go release.

### Bump codecov action version 

The old version used node 12 which is [deprecated by GitHub Actions](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

### Use goreleaser action

Instead of installing goreleaser by ourselves, we'll let the [goreleaser action](https://goreleaser.com/ci/actions/) install it. 

### Add @dependabot configuration

Let @dependabot create pull requests for new dependencies in `go.mod`, `Dockerfile`, and GitHub Actions. This should make it easier to stay up-to-date.
  
### Add GitHub Action permissions

GitHub has introduced [permissions for GitHub Actions](https://docs.github.com/en/rest/actions/permissions) to increase the safety of the actions.