### PR TITLE
Remove duplicate URLs so we don't send to the same service twice

### DIFF
--- a/internal/dedupe/dedupe.go
+++ b/internal/dedupe/dedupe.go
@@ -1,0 +1,21 @@
+package dedupe
+
+// RemoveDuplicates from a slice of strings
+func RemoveDuplicates(src []string) []string {
+	unique := make([]string, 0, len(src))
+
+	for _, s := range src {
+		found := false
+		for _, us := range unique {
+			if us == s {
+				found = true
+				break
+			}
+		}
+		if !found {
+			unique = append(unique, s)
+		}
+	}
+
+	return unique
+}

--- a/internal/dedupe/dedupe_test.go
+++ b/internal/dedupe/dedupe_test.go
@@ -1,0 +1,29 @@
+package dedupe_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/containrrr/shoutrrr/internal/dedupe"
+)
+
+func TestRemoveDuplicates(t *testing.T) {
+	tests := map[string]struct {
+		input []string
+		want  []string
+	}{
+		"no duplicates":                             {input: []string{"a", "b", "c"}, want: []string{"a", "b", "c"}},
+		"duplicate inside slice":                    {input: []string{"a", "b", "a", "c"}, want: []string{"a", "b", "c"}},
+		"duplicate at end of slice":                 {input: []string{"a", "b", "c", "a"}, want: []string{"a", "b", "c"}},
+		"duplicate next to each other inside slice": {input: []string{"a", "b", "b", "c"}, want: []string{"a", "b", "c"}},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := dedupe.RemoveDuplicates(tc.input)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("expected: %#v, got: %#v", tc.want, got)
+			}
+		})
+	}
+}

--- a/shoutrrr/cmd/send/send.go
+++ b/shoutrrr/cmd/send/send.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/containrrr/shoutrrr/internal/dedupe"
 	intutil "github.com/containrrr/shoutrrr/internal/util"
 	"github.com/containrrr/shoutrrr/pkg/router"
 	"github.com/containrrr/shoutrrr/pkg/types"
@@ -46,6 +47,7 @@ func run(cmd *cobra.Command) error {
 	verbose, _ := flags.GetBool("verbose")
 
 	urls, _ := flags.GetStringArray("url")
+	urls = dedupe.RemoveDuplicates(urls)
 	message, _ := flags.GetString("message")
 	title, _ := flags.GetString("title")
 


### PR DESCRIPTION
It doesn't make much sense to send a message to the same service twice.

It's probably not likely that a user will make the mistake by adding the same service twice by adding it twice on the command
line (`shoutrrr send --url=my://service --url=my://service`), but in a script or Docker setup it could happen accidentally using an environment variable like this:

```bash
export SHOUTRRR_URL=my://service

shoutrrr --url=${SHOUTRRR_URL}
```

This has happened to me in a Docker setup. And I'm not too proud to admit that it took me a long time before I figured out why each message was duplicated...