### PR TITLE
Make the cli available as a snap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,3 +134,20 @@ jobs:
         run: |
           docker manifest push containrrr/shoutrrr:${GITHUB_REF/refs\/tags\/v/} && \
           docker manifest push containrrr/shoutrrr:latest
+  snap:
+    name: Build Shoutrrr snap
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout repository
+      - uses: snapcore/action-build@v1
+        name: Build snap
+        id: build
+      - uses: snapcore/action-publish@v1
+        name: Release snap
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: edge

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.so
 *.dylib
 /shoutrrr/shoutrrr
+*.snap
 
 # Test binary, build with `go test -c`
 # ---

--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ Heavily inspired by <a href="https://github.com/caronc/apprise">caronc/apprise</
 </div>
 <br/><br/>
 
+## Installation
+
+### Using the snap
+
+```bash
+$ sudo snap install shoutrrr
+```
+
+### Using the Go CLI
+
+```bash
+$ go install github.com/containrrr/shoutrrr@latest
+```
+
+### From Source
+
+```bash
+$ go build -o shoutrrr .
+```
+
 ## Quick Start
 
 ### As a package

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,30 @@
+name: shoutrrr 
+base: core22 
+version: '0.6.1' 
+summary: Sending notifications made easy. 
+description: |
+  Shoutrrr is a way of making the sending of notifications easy by standardizing it.
+grade: stable 
+confinement: strict 
+contact: https://github.com/containrrr/shoutrrr/discussions
+issues: https://github.com/containrrr/shoutrrr/issues
+icon: docs/shoutrrr-logotype.png
+license: MIT
+source-code: https://github.com/containrrr/shoutrrr
+type: app
+
+
+apps:
+  shoutrrr:
+    command: bin/shoutrrr
+
+parts:
+  shoutrrr:
+    plugin: go
+    source: . 
+    source-type: git
+    build-packages:
+      - golang
+    build-environment:
+      - CGO_ENABLED: 0
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,7 @@ icon: docs/shoutrrr-logotype.png
 license: MIT
 source-code: https://github.com/containrrr/shoutrrr
 type: app
+compression: lzo
 
 
 apps:


### PR DESCRIPTION
<!--

Thank you for contributing to the shoutrrr project! 🙏

We truly appreciate all the contributions we get from the community.
To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->

Given how good and easy the CLI has become to use, it only makes sense for it to also be available as a snap on the snapstore. I've gone ahead and registered the snap name already and published a revision on the stable track.

This PR moves the ownership of the snap packing spec to the containrrr team.

[Snapstore Entry](https://snapcraft.io/shoutrrr)