### PR TITLE
fix(generic): prevent mutation of params

### DIFF
--- a/pkg/services/generic/generic_test.go
+++ b/pkg/services/generic/generic_test.go
@@ -151,8 +151,8 @@ var _ = Describe("the Generic service", func() {
 			It("should create a JSON object as the payload", func() {
 				config.Template = "JSON"
 				params := types.Params{"title": "test title"}
-				updateParams(&config, params, "test message")
-				payload, err := service.getPayload(&config, params)
+				sendParams := createSendParams(&config, params, "test message")
+				payload, err := service.getPayload(&config, sendParams)
 				Expect(err).NotTo(HaveOccurred())
 				contents, err := ioutil.ReadAll(payload)
 				Expect(err).NotTo(HaveOccurred())
@@ -167,8 +167,8 @@ var _ = Describe("the Generic service", func() {
 					config.MessageKey = "body"
 					config.TitleKey = "header"
 					params := types.Params{"title": "test title"}
-					updateParams(&config, params, "test message")
-					payload, err := service.getPayload(&config, params)
+					sendParams := createSendParams(&config, params, "test message")
+					payload, err := service.getPayload(&config, sendParams)
 					Expect(err).NotTo(HaveOccurred())
 					contents, err := ioutil.ReadAll(payload)
 					Expect(err).NotTo(HaveOccurred())
@@ -267,6 +267,21 @@ var _ = Describe("the Generic service", func() {
 
 			err = service.Send("Message", nil)
 			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should not mutate the given params", func() {
+			serviceURL, _ := url.Parse("generic://host.tld/webhook?method=GET")
+			err = service.Initialize(serviceURL, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			targetURL := "https://host.tld/webhook"
+			httpmock.RegisterResponder("GET", targetURL, httpmock.NewStringResponder(200, ""))
+
+			params := types.Params{"title": "TITLE"}
+
+			err = service.Send("Message", &params)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(params).To(Equal(types.Params{"title": "TITLE"}))
 		})
 	})
 })

--- a/pkg/types/params.go
+++ b/pkg/types/params.go
@@ -4,7 +4,9 @@ package types
 type Params map[string]string
 
 const (
-	TitleKey   = "title"
+	// TitleKey is the common key for the title prop
+	TitleKey = "title"
+	// MessageKey is the common key for the message prop
 	MessageKey = "message"
 )
 

--- a/pkg/types/params.go
+++ b/pkg/types/params.go
@@ -4,22 +4,22 @@ package types
 type Params map[string]string
 
 const (
-	titleKey   = "title"
-	messageKey = "message"
+	TitleKey   = "title"
+	MessageKey = "message"
 )
 
 // SetTitle sets the "title" param to the specified value
 func (p Params) SetTitle(title string) {
-	p[titleKey] = title
+	p[TitleKey] = title
 }
 
 // Title returns the "title" param
 func (p Params) Title() (title string, found bool) {
-	title, found = p[titleKey]
+	title, found = p[TitleKey]
 	return
 }
 
 // SetMessage sets the "message" param to the specified value
 func (p Params) SetMessage(message string) {
-	p[messageKey] = message
+	p[MessageKey] = message
 }


### PR DESCRIPTION
The params passed to the services should not be mutated. This unfortunately wasn't true for `generic`, so this PR rectifies that.

fixes #309 
