### PR TITLE
docs(generic): add home assistant example

### DIFF
--- a/docs/examples/generic.md
+++ b/docs/examples/generic.md
@@ -1,6 +1,6 @@
 # Examples
 
-Examples of service URLs that can be used with [the generic service](../generic) together with common service providers.
+Examples of service URLs that can be used with [the generic service](../../services/generic) together with common service providers.
 
 ## Home Assistant
 
@@ -16,4 +16,4 @@ generic://HAIPAddress:HAPort/api/webhook/WebhookIDFromHA?template=json&disabletl
 
 Then, in HA, use `{{ trigger.json.message }}` to get the message sent from the JSON.
 
-_Credit [@JeffCrum1](https://github.com/JeffCrum1), source: https://github.com/containrrr/shoutrrr/issues/325#issuecomment-1460105065_
+_Credit [@JeffCrum1](https://github.com/JeffCrum1), source: [https://github.com/containrrr/shoutrrr/issues/325#issuecomment-1460105065]_

--- a/docs/services/generic.md
+++ b/docs/services/generic.md
@@ -4,7 +4,7 @@ supports receiving the message via a POST request.
 Usually, this requires customization on the receiving end to interpret the payload that it receives, and might
 not be a viable approach.
 
-Common examples for use with service providers can be found under [examples](generic/examples).
+Common examples for use with service providers can be found under [examples](../examples/generic.md).
 
 ## JSON template
 By using the built in `JSON` template (`template=json`) you can create a generic JSON payload. The keys used for `title` and `message` can be overriden

--- a/docs/services/generic.md
+++ b/docs/services/generic.md
@@ -29,7 +29,7 @@ generic+https://example.com/api/v1/postStuff
 ```
 
 !!! note
-    Any query variables added to the URL will be escaped so that they can be forwarded to the remote server. That means that you cannot use `?format=json` with the  `generic+https://`, just use `generic://` instead!
+    Any query variables added to the URL will be escaped so that they can be forwarded to the remote server. That means that you cannot use `?template=json` with the  `generic+https://`, just use `generic://` instead!
 
 ## Forwarded query variables
 All query variables that are not listed in the [Query/Param Props](#queryparam_props) section will be

--- a/docs/services/generic.md
+++ b/docs/services/generic.md
@@ -4,6 +4,8 @@ supports receiving the message via a POST request.
 Usually, this requires customization on the receiving end to interpret the payload that it receives, and might
 not be a viable approach.
 
+Common examples for use with service providers can be found under [examples](generic/examples).
+
 ## JSON template
 By using the built in `JSON` template (`template=json`) you can create a generic JSON payload. The keys used for `title` and `message` can be overriden
 by supplying the params/query values `titleKey` and `messageKey`.
@@ -25,6 +27,9 @@ would become
 ```
 generic+https://example.com/api/v1/postStuff
 ```
+
+!!! note
+    Any query variables added to the URL will be escaped so that they can be forwarded to the remote server. That means that you cannot use `?format=json` with the  `generic+https://`, just use `generic://` instead!
 
 ## Forwarded query variables
 All query variables that are not listed in the [Query/Param Props](#queryparam_props) section will be

--- a/docs/services/generic/examples.md
+++ b/docs/services/generic/examples.md
@@ -1,0 +1,19 @@
+# Examples
+
+Examples of service URLs that can be used with [the generic service](../generic) together with common service providers.
+
+## Home Assistant
+
+The service URL needs to be:
+```
+generic://HAIPAddress:HAPort/api/webhook/WebhookIDFromHA?template=json
+```
+
+And, if you need http://
+```
+generic://HAIPAddress:HAPort/api/webhook/WebhookIDFromHA?template=json&disabletls=yes
+```
+
+Then, in HA, use `{{ trigger.json.message }}` to get the message sent from the JSON.
+
+_Credit [@JeffCrum1](https://github.com/JeffCrum1), source: https://github.com/containrrr/shoutrrr/issues/325#issuecomment-1460105065_

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,8 @@ nav:
       - Generic Webhook: 'services/generic.md'
   - Guides:
       - Slack: 'guides/slack/index.md'
+  - Examples:
+      - Generic Webhook: 'examples/generic.md'
   - Advanced usage:
       - Proxy: 'proxy.md'
 


### PR DESCRIPTION
This adds the information provided by @jeffcrum1 as an example of how to use the generic service with home assistant. It also adds a note about the `template=json` not being usable with the `generic+` helper.
