### PR TITLE
fix(ifttt): treat all 2xx http responses as success

### DIFF
--- a/pkg/services/ifttt/ifttt.go
+++ b/pkg/services/ifttt/ifttt.go
@@ -72,7 +72,7 @@ func doSend(payload []byte, postURL string) error {
 	if err != nil {
 		return err
 	}
-	if res.StatusCode != http.StatusNoContent {
+	if res.StatusCode != http.StatusNoContent && res.StatusCode != http.StatusOK {
 		return fmt.Errorf("got response status code %s", res.Status)
 	}
 	return nil

--- a/pkg/services/ifttt/ifttt.go
+++ b/pkg/services/ifttt/ifttt.go
@@ -3,9 +3,10 @@ package ifttt
 import (
 	"bytes"
 	"fmt"
-	"github.com/containrrr/shoutrrr/pkg/format"
 	"net/http"
 	"net/url"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
 
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	"github.com/containrrr/shoutrrr/pkg/types"
@@ -72,7 +73,7 @@ func doSend(payload []byte, postURL string) error {
 	if err != nil {
 		return err
 	}
-	if res.StatusCode != http.StatusNoContent && res.StatusCode != http.StatusOK {
+	if res.StatusCode > 299 || res.StatusCode < 200 {
 		return fmt.Errorf("got response status code %s", res.Status)
 	}
 	return nil


### PR DESCRIPTION
Originally, shoutrrr sees only http status code 204 as a successful response from IFTTT webhook service.
However, http status code 200 should be also seen has a successful response.

This prevents an incorrect error log from generating.