### PR TITLE
feat(generic): extra data and custom headers

### DIFF
--- a/docs/services/generic.md
+++ b/docs/services/generic.md
@@ -6,16 +6,15 @@ not be a viable approach.
 
 Common examples for use with service providers can be found under [examples](../examples/generic.md).
 
-
 ## Custom headers
 You can add additional HTTP headers to your request by adding query variables prefixed with `@` (`@key=value`).
 
 Using 
-```
+```url
 generic://example.com?@acceptLanguage=tlh-Piqd
 ```
 would result in the additional header being added:
-```
+```http request
 Accept-Language: tlh-Piqd
 ```
 
@@ -35,7 +34,6 @@ by supplying the params/query values `titleKey` and `messageKey`.
 When using the JSON template, you can add additional key/value pairs to the JSON object by adding query variables prefixed with `$` (`$key=value`).
 
 !!! example
-    
     Using `generic://example.com?$projection=retroazimuthal` would yield: 
 
     ```json
@@ -48,11 +46,11 @@ When using the JSON template, you can add additional key/value pairs to the JSON
 
 ## Shortcut URL
 You can just add `generic+` as a prefix to your target URL to use it with the generic service, so
-```
+```url
 https://example.com/api/v1/postStuff
 ```
 would become
-```
+```url
 generic+https://example.com/api/v1/postStuff
 ```
 

--- a/docs/services/generic.md
+++ b/docs/services/generic.md
@@ -6,6 +6,19 @@ not be a viable approach.
 
 Common examples for use with service providers can be found under [examples](../examples/generic.md).
 
+
+## Custom headers
+You can add additional HTTP headers to your request by adding query variables prefixed with `@` (`@key=value`).
+
+Using 
+```
+generic://example.com?@acceptLanguage=tlh-Piqd
+```
+would result in the additional header being added:
+```
+Accept-Language: tlh-Piqd
+```
+
 ## JSON template
 By using the built in `JSON` template (`template=json`) you can create a generic JSON payload. The keys used for `title` and `message` can be overriden
 by supplying the params/query values `titleKey` and `messageKey`.
@@ -15,6 +28,21 @@ by supplying the params/query values `titleKey` and `messageKey`.
     {
         "title": "Oh no!",
         "message": "The thing happened and now there is stuff all over the area!"
+    }
+    ```
+
+### Custom data fields
+When using the JSON template, you can add additional key/value pairs to the JSON object by adding query variables prefixed with `$` (`$key=value`).
+
+!!! example
+    
+    Using `generic://example.com?$projection=retroazimuthal` would yield: 
+
+    ```json
+    {
+        "title": "Amazing opportunities!",
+        "message": "New map book available for purchase.",
+        "projection": "retroazimuthal"
     }
     ```
 

--- a/pkg/services/generic/custom_query.go
+++ b/pkg/services/generic/custom_query.go
@@ -1,0 +1,56 @@
+package generic
+
+import (
+	"net/url"
+	"strings"
+)
+
+const extraPrefix = '$'
+const headerPrefix = '@'
+const caseOffset = 'a' - 'A'
+
+func normalizedHeaderKey(key string) string {
+	sb := strings.Builder{}
+	sb.Grow(len(key) * 2)
+	for i, c := range key {
+		if 'A' <= c && c <= 'Z' {
+			// Char is uppercase
+			if i > 0 && key[i-1] != '-' {
+				// Add missing dash
+				sb.WriteRune('-')
+			}
+		} else if i == 0 || key[i-1] == '-' {
+			// First char, or previous was dash
+			c -= caseOffset
+		}
+		sb.WriteRune(c)
+	}
+	return sb.String()
+}
+
+func appendCustomQueryValues(query url.Values, headers map[string]string, extraData map[string]string) {
+	for key, value := range headers {
+		query.Set(string(headerPrefix)+key, value)
+	}
+	for key, value := range extraData {
+		query.Set(string(extraPrefix)+key, value)
+	}
+}
+
+func stripCustomQueryValues(query url.Values) (headers, extraData map[string]string) {
+	headers = make(map[string]string)
+	extraData = make(map[string]string)
+
+	for key, values := range query {
+		if key[0] == headerPrefix {
+			headerKey := normalizedHeaderKey(key[1:])
+			headers[headerKey] = values[0]
+		} else if key[0] == extraPrefix {
+			extraData[key[1:]] = values[0]
+		} else {
+			continue
+		}
+		delete(query, key)
+	}
+	return headers, extraData
+}


### PR DESCRIPTION
Add support for `@header=value` and `$data=value` query parameters for the generic service.

This also enables support for header-based authentication, i.e. by using `?@authorization=Bearer+TOKEN`.

Fixes #365
Fixes #366

