### PR TITLE
fix(bark): fix param url

### DIFF
--- a/pkg/services/bark/bark.go
+++ b/pkg/services/bark/bark.go
@@ -58,6 +58,7 @@ func (service *Service) sendAPI(config *Config, message string) error {
 		Group:     config.Group,
 		Badge:     &config.Badge,
 		Icon:      config.Icon,
+		URL:       config.URL,
 	}
 	jsonClient := jsonclient.NewClient()
 


### PR DESCRIPTION
fix the missing param `url` for Bark service