### PR TITLE
fix(smtp): allow usehtml to be set in params

### DIFF
--- a/pkg/services/smtp/smtp.go
+++ b/pkg/services/smtp/smtp.go
@@ -205,7 +205,7 @@ func (service *Service) sendToRecipient(client *smtp.Client, toAddress string, c
 		return fail(FailOpenDataStream, err)
 	}
 
-	if err := writeHeaders(wc, service.getHeaders(toAddress, config.Subject)); err != nil {
+	if err := writeHeaders(wc, service.getHeaders(config, toAddress)); err != nil {
 		return err
 	}
 
@@ -227,21 +227,17 @@ func (service *Service) sendToRecipient(client *smtp.Client, toAddress string, c
 	return nil
 }
 
-func (service *Service) getHeaders(toAddress string, subject string) map[string]string {
-	conf := service.config
-
-	var contentType string
-	if conf.UseHTML {
+func (service *Service) getHeaders(config *Config, toAddress string) map[string]string {
+	contentType := contentPlain
+	if config.UseHTML {
 		contentType = fmt.Sprintf(contentMultipart, service.multipartBoundary)
-	} else {
-		contentType = contentPlain
 	}
 
 	return map[string]string{
-		"Subject":      subject,
+		"Subject":      config.Subject,
 		"Date":         time.Now().Format(time.RFC1123Z),
 		"To":           toAddress,
-		"From":         fmt.Sprintf("%s <%s>", conf.FromName, conf.FromAddress),
+		"From":         fmt.Sprintf("%s <%s>", config.FromName, config.FromAddress),
 		"MIME-version": "1.0",
 		"Content-Type": contentType,
 	}

--- a/pkg/services/smtp/smtp_config.go
+++ b/pkg/services/smtp/smtp_config.go
@@ -29,13 +29,13 @@ type Config struct {
 	ClientHost  string    `desc:"The client host name sent to the SMTP server during HELLO phase. If set to \"auto\" it will use the OS hostname" key:"clienthost" default:"localhost"`
 }
 
-// GetURL returns a URL representation of it's current field values
+// GetURL returns a URL representation of its current field values
 func (config *Config) GetURL() *url.URL {
 	resolver := format.NewPropKeyResolver(config)
 	return config.getURL(&resolver)
 }
 
-// SetURL updates a ServiceConfig from a URL representation of it's field values
+// SetURL updates a ServiceConfig from a URL representation of its field values
 func (config *Config) SetURL(url *url.URL) error {
 	resolver := format.NewPropKeyResolver(config)
 	return config.setURL(&resolver, url)
@@ -100,7 +100,7 @@ func (config *Config) FixEmailTags() {
 }
 
 // Enums returns the fields that should use a corresponding EnumFormatter to Print/Parse their values
-func (config Config) Enums() map[string]types.EnumFormatter {
+func (config *Config) Enums() map[string]types.EnumFormatter {
 	return map[string]types.EnumFormatter{
 		"Auth":       AuthTypes.Enum,
 		"Encryption": EncMethods.Enum,


### PR DESCRIPTION
Use the configuration updated from props in `getHeaders`, allowing `FromName`, `FromAddress` and `UseHTML` to be overridden in params.

Fixes #387 