### PR TITLE
fix(matrix): add missing txid to send message call

### DIFF
--- a/pkg/services/matrix/matrix.go
+++ b/pkg/services/matrix/matrix.go
@@ -2,10 +2,11 @@ package matrix
 
 import (
 	"fmt"
+	"net/url"
+
 	"github.com/containrrr/shoutrrr/pkg/format"
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	t "github.com/containrrr/shoutrrr/pkg/types"
-	"net/url"
 )
 
 // Scheme is the identifying part of this service's configuration URL
@@ -49,7 +50,7 @@ func (s *Service) Send(message string, params *t.Params) error {
 
 	if len(errors) > 0 {
 		for _, err := range errors {
-			s.Logf("error sending message: %w", err)
+			s.Logf("error sending message: %v", err)
 		}
 		return fmt.Errorf("%v error(s) sending message, with initial error: %v", len(errors), errors[0])
 	}

--- a/pkg/services/matrix/matrix_api.go
+++ b/pkg/services/matrix/matrix_api.go
@@ -7,7 +7,7 @@ type identifierType string
 const (
 	apiLogin       = "/_matrix/client/r0/login"
 	apiRoomJoin    = "/_matrix/client/r0/join/%s"
-	apiSendMessage = "/_matrix/client/r0/rooms/%s/send/m.room.message"
+	apiSendMessage = "/_matrix/client/r0/rooms/%s/send/m.room.message/%v"
 	apiJoinedRooms = "/_matrix/client/r0/joined_rooms"
 
 	contentType = "application/json"

--- a/pkg/services/matrix/matrix_test.go
+++ b/pkg/services/matrix/matrix_test.go
@@ -167,13 +167,13 @@ func setupMockResponders() {
 		mockServer+apiJoinedRooms,
 		httpmock.NewStringResponder(200, `{ "joined_rooms": [ "!room:mockserver" ] }`))
 
-	httpmock.RegisterResponder("POST", mockServer+fmt.Sprintf(apiSendMessage, "%21room:mockserver"),
+	httpmock.RegisterResponder("PUT", `=~`+mockServer+fmt.Sprintf(apiSendMessage, "%21room:mockserver", `[0-9]+`),
 		httpmock.NewJsonResponderOrPanic(200, apiResEvent{EventID: "7"}))
 
-	httpmock.RegisterResponder("POST", mockServer+fmt.Sprintf(apiSendMessage, "1"),
+	httpmock.RegisterResponder("PUT", `=~`+mockServer+fmt.Sprintf(apiSendMessage, "1", `[0-9]+`),
 		httpmock.NewJsonResponderOrPanic(200, apiResEvent{EventID: "8"}))
 
-	httpmock.RegisterResponder("POST", mockServer+fmt.Sprintf(apiSendMessage, "2"),
+	httpmock.RegisterResponder("PUT", `=~`+mockServer+fmt.Sprintf(apiSendMessage, "2", `[0-9]+`),
 		httpmock.NewJsonResponderOrPanic(200, apiResEvent{EventID: "9"}))
 
 	httpmock.RegisterResponder("POST", mockServer+fmt.Sprintf(apiRoomJoin, "%23room1"),


### PR DESCRIPTION
The Matrix Client/Server spec requires that the send message endpoint includes a unique transaction id with each request. The matrix service omits this id for some reason, and the original testing server probably allowed this.

This PR adds an incrementing counter as the transaction ID, which should allow it to work with conduit matrix server.

Fixes #415.
