### PR TITLE
feat: support ntfy template parameter

### DIFF
--- a/pkg/services/ntfy/ntfy_config.go
+++ b/pkg/services/ntfy/ntfy_config.go
@@ -27,6 +27,8 @@ type Config struct {
 	Icon     string   `key:"icon"        optional:""         desc:"URL to use as notification icon"`
 	Cache    bool     `key:"cache"       default:"yes"       desc:"Cache messages"`
 	Firebase bool     `key:"firebase"    default:"yes"       desc:"Send to firebase"`
+	Template bool     `key:"template"    default:"no"        desc:"Use message and title as template"`
+	Message  string   `key:"message"     optional:""         desc:"Message, to be used only then template is set to true"`
 }
 
 // Enums implements types.ServiceConfig


### PR DESCRIPTION
Adds support for ntfy templated messages by using the template param to enable custom formats in the message and title parameters as specified in the ntfy documentation:

https://docs.ntfy.sh/publish/#message-templating

Using this new `template` parameter requires that at least the `title` or the `message` (new parameter) are set. Added some tests to handle possible scenarios.

I'm unsure how to update the docs to reflect this change since it is inherent to the ntfy service.