### PR TITLE
Update rocketchat.md

### DIFF
--- a/docs/services/rocketchat.md
+++ b/docs/services/rocketchat.md
@@ -23,8 +23,8 @@
 
 6. Format the service URL
 ```
-rocketchat://your-domain.com/8eGdRzc9r4YYNyvge/2XYQcX9NBwJBKfQnphpebPcnXZcPEi32Nt4NKJfrnbhsbRfX
-                             └────────────────────────────────────────────────────────────────┘
+rocketchat://your-domain.com/hooks/8eGdRzc9r4YYNyvge/2XYQcX9NBwJBKfQnphpebPcnXZcPEi32Nt4NKJfrnbhsbRfX
+                                   └────────────────────────────────────────────────────────────────┘
                                                            token
 ```
 
@@ -35,12 +35,12 @@ Rocket.chat provides functionality to post as another user or to another channel
 To do this, you can add a *sender* and/or *channel* / *receiver* to the service URL.
 
 ```
-rocketchat://shoutrrrUser@your-domain.com/8eGdRzc9r4YYNyvge/2XYQcX9NBwJBKfQnphpebPcnXZcPEi32Nt4NKJfrnbhsbRfX/shoutrrrChannel
-             └──────────┘                 └────────────────────────────────────────────────────────────────┘ └─────────────┘
+rocketchat://shoutrrrUser@your-domain.com/hooks/8eGdRzc9r4YYNyvge/2XYQcX9NBwJBKfQnphpebPcnXZcPEi32Nt4NKJfrnbhsbRfX/shoutrrrChannel
+             └──────────┘                       └────────────────────────────────────────────────────────────────┘ └─────────────┘
                 sender                                                   token                                   channel
 
-rocketchat://shoutrrrUser@your-domain.com/8eGdRzc9r4YYNyvge/2XYQcX9NBwJBKfQnphpebPcnXZcPEi32Nt4NKJfrnbhsbRfX/@shoutrrrReceiver
-             └──────────┘                 └────────────────────────────────────────────────────────────────┘ └───────────────┘
+rocketchat://shoutrrrUser@your-domain.com/hooks/8eGdRzc9r4YYNyvge/2XYQcX9NBwJBKfQnphpebPcnXZcPEi32Nt4NKJfrnbhsbRfX/@shoutrrrReceiver
+             └──────────┘                       └────────────────────────────────────────────────────────────────┘ └───────────────┘
                 sender                                                   token                                    receiver
 ```
 


### PR DESCRIPTION
- What your PR contributes

Fixes Rocket.Chat integration URL examples for notifications - `/hooks` segment was missing, creating a misleading documentation.

- Which issues it solves (preferrably using auto closing instructions like "closes xyz".

No open issues so far, may open if it's required. I came in this repo on my path of investigation for a deployment issue between my application and Rocket.Chat.

- Tests that verify the code your contributing

Initially, I've followed instructions in the Kured project, that copies this document as is, since they are using shoutrr to provide such a functionality.
That led to integration errors (HTTP 404 in particular) on notification attempts.
After the URL was changed to include `/hooks`, as it is created and presented by the Rocket.Chat, everything works as designed.

- Updates to the documentation

Whole changeset is dedicated to the documentation fix.