### PR TITLE
feat: supported lark custom bot webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 *.out
 .idea
+.vscode
 
 report.json
 coverage.txt

--- a/docs/services/lark.md
+++ b/docs/services/lark.md
@@ -1,0 +1,44 @@
+# Lark
+
+## URL Format
+
+!!! info ""
+    lark://__`host`__/__`token`__?[secret=__`secret`__]
+    
+--8<-- "docs/services/lark/config.md"
+
+## Create Custom Bot in Lark
+
+Official Documents: [Link](https://open.larksuite.com/document/client-docs/bot-v3/add-custom-bot)
+
+1. Invite custom bot join group.
+
+    a. Enter the target group, click the `More` button in the upper right corner of the group, and then click `Settings`.
+    
+    b. On the right-side `Settings`, click on `Group Bot`.
+
+    c. Click `Add a Bot` on the `Group Bot`.
+
+    b. In `Add Bot` dialog box, find the `Custom Bot` and add it.
+
+    e. Set the name and description of the custom robot, and click `Add`.
+
+2. Get the webhook address of the custom robot and click `Finish`.
+
+## Get Host and Token of Custom Bot
+
+If you are using `Lark`, then the `Host` is `open.larksuite.com`.
+
+If you are using `Feishu` or `飞书`, then the `Host` is `open.feishu.cn`.
+
+`Token` is the last part of the webhook address. For example, if the webhook address is `https://open.larksuite.com/open-apis/bot/v2/hook/xxxxxxxxxxxxxxxxx`, then the token corresponds to `xxxxxxxxxxxxxxxxx`.
+
+## Get Secret of Custom Bot
+
+1. In the group settings, open the bot list, find the custom bot and click on it to enter the configuration page.
+
+2. In the `Security Settings`, select `Signature Verification`.
+
+3. Click `Copy` to copy the secret.
+
+4. Click `Save` to make the configuration take effect.

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -22,6 +22,7 @@ Click on the service for a more thorough explanation. <!-- @formatter:off -->
 | [Teams](./teams.md)               | *teams://__`group`__@__`tenant`__/__`altId`__/__`groupOwner`__?host=__`organization`__.webhook.office.com*                                      |
 | [Telegram](./telegram.md)         | *telegram://__`token`__@telegram?chats=__`@channel-1`__[,__`chat-id-1`__,...]*                                                                  |
 | [Zulip Chat](./zulip.md)          | *zulip://__`bot-mail`__:__`bot-key`__@__`zulip-domain`__/?stream=__`name-or-id`__&topic=__`name`__*                                             |
+| [Lark](./lark.md)                 | *lark://__`host`__/__`token`__?secret=__`secret`__*                                                                                             |
 
 ## Specialized services
 

--- a/pkg/router/servicemap.go
+++ b/pkg/router/servicemap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containrrr/shoutrrr/pkg/services/gotify"
 	"github.com/containrrr/shoutrrr/pkg/services/ifttt"
 	"github.com/containrrr/shoutrrr/pkg/services/join"
+	"github.com/containrrr/shoutrrr/pkg/services/lark"
 	"github.com/containrrr/shoutrrr/pkg/services/logger"
 	"github.com/containrrr/shoutrrr/pkg/services/matrix"
 	"github.com/containrrr/shoutrrr/pkg/services/mattermost"
@@ -46,4 +47,5 @@ var serviceMap = map[string]func() t.Service{
 	"teams":      func() t.Service { return &teams.Service{} },
 	"telegram":   func() t.Service { return &telegram.Service{} },
 	"zulip":      func() t.Service { return &zulip.Service{} },
+	"lark":       func() t.Service { return &lark.Service{} },
 }

--- a/pkg/services/lark/lark.go
+++ b/pkg/services/lark/lark.go
@@ -1,0 +1,145 @@
+package lark
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/services/standard"
+	"github.com/containrrr/shoutrrr/pkg/types"
+)
+
+const (
+	apiFormat   = "https://%s/open-apis/bot/v2/hook/%s"
+	maxLength   = 4096
+	defaultTime = 30 * time.Second
+)
+
+type Service struct {
+	standard.Standard
+	config *Config
+	pkr    format.PropKeyResolver
+}
+
+var (
+	ErrInvalidHost  = errors.New("invalid host, use 'open.larksuite.com' or 'open.feishu.cn'")
+	ErrNoPath       = errors.New("no path, path like 'xxx' in 'https://open.larksuite.com/open-apis/bot/v2/hook/xxx'")
+	ErrLargeMessage = errors.New("message exceeds the max length")
+
+	httpClient = &http.Client{Timeout: defaultTime}
+)
+
+const (
+	larkHost   = "open.larksuite.com"
+	feishuHost = "open.feishu.com"
+)
+
+// Send notification to Lark
+func (service *Service) Send(message string, params *types.Params) error {
+	if len(message) > maxLength {
+		return ErrLargeMessage
+	}
+
+	config := *service.config
+	if err := service.pkr.UpdateConfigFromParams(&config, params); err != nil {
+		return err
+	}
+
+	if config.Host != larkHost && config.Host != feishuHost {
+		return ErrInvalidHost
+	}
+
+	if config.Path == "" {
+		return ErrNoPath
+	}
+
+	return service.sendMessage(message, config)
+}
+
+// Initialize loads ServiceConfig from configURL and sets logger for this Service
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
+	service.Logger.SetLogger(logger)
+	service.config = &Config{}
+	service.pkr = format.NewPropKeyResolver(service.config)
+	if err := service.config.setURL(&service.pkr, configURL); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (service *Service) genSign(secret string, timestamp int64) string {
+	//timestamp + key calculate sha256, then base64 encode
+	stringToSign := fmt.Sprintf("%v", timestamp) + "\n" + secret
+
+	var data []byte
+	h := hmac.New(sha256.New, []byte(stringToSign))
+	h.Write(data)
+	signature := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	return signature
+}
+
+func (service *Service) sendMessage(message string, cfg Config) error {
+	url := fmt.Sprintf(apiFormat, cfg.Host, cfg.Path)
+	body := service.getRequestBody(message, cfg.Title, cfg.Secret)
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	service.Logf("Lark Request Body: %s", string(data))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	response := Response{}
+	if err := json.Unmarshal(data, &response); err != nil {
+		return err
+	}
+	if response.Code == 0 {
+		return nil
+	}
+	return fmt.Errorf("code: %d, msg: %s", response.Code, response.Msg)
+}
+
+func (service *Service) getRequestBody(message, title, secret string) *RequestBody {
+	body := &RequestBody{}
+	if secret != "" {
+		ts := time.Now().Unix()
+		body.Timestamp = strconv.FormatInt(ts, 10)
+		body.Sign = service.genSign(secret, ts)
+	}
+	if title == "" {
+		body.MsgType = MsgTypeText
+		body.Content.Text = message
+		return body
+	}
+	body.MsgType = MsgTypePost
+	body.Content.Post = &Post{
+		En: &Message{
+			Title: title,
+			Content: [][]Item{{
+				{Tag: TagValueText, Text: message},
+			}},
+		},
+	}
+	return body
+}

--- a/pkg/services/lark/lark_config.go
+++ b/pkg/services/lark/lark_config.go
@@ -1,0 +1,59 @@
+package lark
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
+)
+
+const Scheme = "lark"
+
+type Config struct {
+	Host   string `desc:"Custom bot URL Host" default:"open.larksuite.com" url:"Host"`
+	Secret string `desc:"Custom bot secret" default:"" key:"secret"`
+	Path   string `desc:"Custom bot token" url:"Path"`
+	Title  string `desc:"Message Title" default:"" key:"title"`
+}
+
+func (config *Config) Enums() map[string]types.EnumFormatter {
+	return map[string]types.EnumFormatter{}
+}
+
+func (config *Config) GetURL() *url.URL {
+	resolver := format.NewPropKeyResolver(config)
+	return config.getURL(&resolver)
+}
+
+func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
+
+	return &url.URL{
+		Host:       config.Host,
+		Path:       "/" + config.Path,
+		Scheme:     Scheme,
+		ForceQuery: true,
+		RawQuery:   format.BuildQuery(resolver),
+	}
+
+}
+
+func (config *Config) SetURL(url *url.URL) error {
+	resolver := format.NewPropKeyResolver(config)
+	return config.setURL(&resolver, url)
+}
+
+func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) error {
+
+	config.Host = url.Host
+	config.Path = strings.Trim(url.Path, "/")
+	// config.Password = url.Hostname()
+
+	for key, vals := range url.Query() {
+		if err := resolver.Set(key, vals[0]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/lark/lark_message.go
+++ b/pkg/services/lark/lark_message.go
@@ -1,0 +1,49 @@
+package lark
+
+type RequestBody struct {
+	MsgType   MsgType `json:"msg_type"`
+	Content   Content `json:"content"`
+	Timestamp string  `json:"timestamp,omitempty"`
+	Sign      string  `json:"sign,omitempty"`
+}
+
+type MsgType string
+
+const (
+	MsgTypeText MsgType = "text"
+	MsgTypePost MsgType = "post"
+)
+
+type Content struct {
+	Text string `json:"text,omitempty"`
+	Post *Post  `json:"post,omitempty"`
+}
+
+type Post struct {
+	Zh *Message `json:"zh_cn,omitempty"`
+	En *Message `json:"en_us,omitempty"`
+}
+
+type Message struct {
+	Title   string   `json:"title"`
+	Content [][]Item `json:"content"`
+}
+
+type Item struct {
+	Tag  TagValue `json:"tag"`
+	Text string   `json:"text,omitempty"`
+	Link string   `json:"href,omitempty"`
+}
+
+type TagValue string
+
+const (
+	TagValueText TagValue = "text"
+	TagValueLink TagValue = "a"
+)
+
+type Response struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data any    `json:"data"`
+}

--- a/pkg/services/lark/lark_test.go
+++ b/pkg/services/lark/lark_test.go
@@ -1,0 +1,164 @@
+package lark
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/containrrr/shoutrrr/internal/testutils"
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
+	"github.com/jarcoal/httpmock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var tt *testing.T
+
+func TestLark(t *testing.T) {
+	RegisterFailHandler(Fail)
+	tt = t
+	RunSpecs(t, "Shoutrrr Lark Suite")
+}
+
+var (
+	service *Service
+	logger  *log.Logger
+	_       = BeforeSuite(func() {
+		logger = log.New(GinkgoWriter, "Test", log.LstdFlags)
+	})
+)
+
+const fullURL = "lark://open.larksuite.com/token?secret=sss"
+
+var _ = Describe("Lark Test", func() {
+	BeforeEach(func() {
+		service = &Service{}
+	})
+	When("parsing the configuration URL", func() {
+		It("should be identical after de-/serialization", func() {
+			url := testutils.URLMust(fullURL)
+			config := &Config{}
+			pkr := format.NewPropKeyResolver(config)
+			err := config.setURL(&pkr, url)
+			Expect(err).ShouldNot(HaveOccurred())
+			outputURL := config.GetURL()
+			GinkgoT().Logf("\n\n%s\n%s\n\n-", outputURL, fullURL)
+			Expect(outputURL.String()).To(Equal(fullURL))
+		})
+	})
+	Context("basic service API methods", func() {
+		var config *Config
+		BeforeEach(func() {
+			config = &Config{}
+		})
+		It("should not allow getting invalid query values", func() {
+			testutils.TestConfigGetInvalidQueryValue(config)
+		})
+		It("should not allow setting invalid query values", func() {
+			testutils.TestConfigSetInvalidQueryValue(config, "lark://endpoint/token?secret=sss&foo=bar")
+		})
+		It("should have the expected number of fields and enums", func() {
+			testutils.TestConfigGetEnumsCount(config, 0)
+			testutils.TestConfigGetFieldsCount(config, 2)
+		})
+	})
+	When("sending a message", func() {
+		When("the message is too large", func() {
+			It("should return large messes error", func() {
+				data := make([]string, 410)
+				for i := range data {
+					data[i] = "0123456789"
+				}
+				message := strings.Join(data, "")
+				service := Service{config: &Config{}}
+				Expect(service.Send(message, nil)).To(MatchError(ErrLargeMessage))
+			})
+		})
+		When("the service is not configured correctly", func() {
+			It("should fail when to send message", func() {
+				service := Service{config: &Config{}}
+				Expect(service.Send("test message", nil)).To(MatchError(ErrInvalidHost))
+				service.config.Host = larkHost
+				Expect(service.Send("test message", nil)).To(MatchError(ErrNoPath))
+			})
+		})
+		When("an invalid param is passed", func() {
+			It("should fail to send messages", func() {
+				service := Service{config: &Config{}}
+				Expect(service.Send("test message", &types.Params{"invalid": "value"})).To(MatchError("invalid is not a valid config key []"))
+			})
+		})
+		Context("sending message by http", func() {
+			BeforeEach(func() {
+				httpmock.ActivateNonDefault(httpClient)
+			})
+			AfterEach(func() {
+				httpmock.DeactivateAndReset()
+			})
+			It("should send text message success", func() {
+				httpmock.RegisterResponder(
+					http.MethodPost,
+					"/open-apis/bot/v2/hook/token",
+					httpmock.NewJsonResponderOrPanic(http.StatusOK, map[string]any{"code": 0, "msg": "success"}),
+				)
+				service := &Service{}
+				err := service.Initialize(testutils.URLMust(fullURL), logger)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = service.Send("message", nil)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+			It("should send post message success", func() {
+				httpmock.RegisterResponder(
+					http.MethodPost,
+					"/open-apis/bot/v2/hook/token",
+					httpmock.NewJsonResponderOrPanic(http.StatusOK, map[string]any{"code": 0, "msg": "success"}),
+				)
+				service := &Service{}
+				err := service.Initialize(testutils.URLMust(fullURL), logger)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = service.Send("message", &types.Params{"title": "title"})
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("should return error while request error", func() {
+				httpmock.RegisterResponder(
+					http.MethodPost,
+					"/open-apis/bot/v2/hook/token",
+					httpmock.NewErrorResponder(errors.New("network error")),
+				)
+				service := &Service{}
+				err := service.Initialize(testutils.URLMust(fullURL), logger)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = service.Send("message", nil)
+				Expect(err).Should(MatchError(ContainSubstring("network error")))
+			})
+			It("should return error while response not json", func() {
+				httpmock.RegisterResponder(
+					http.MethodPost,
+					"/open-apis/bot/v2/hook/token",
+					httpmock.NewStringResponder(http.StatusOK, "some response"),
+				)
+				service := &Service{}
+				err := service.Initialize(testutils.URLMust(fullURL), logger)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = service.Send("message", nil)
+				Expect(err).Should(MatchError(ContainSubstring("invalid character")))
+			})
+			It("should return error while response code not zero", func() {
+				httpmock.RegisterResponder(
+					http.MethodPost,
+					"/open-apis/bot/v2/hook/token",
+					httpmock.NewJsonResponderOrPanic(http.StatusOK, map[string]any{"code": 1, "msg": "some error"}),
+				)
+				service := &Service{}
+				err := service.Initialize(testutils.URLMust(fullURL), logger)
+				Expect(err).ShouldNot(HaveOccurred())
+				err = service.Send("message", nil)
+				Expect(err).Should(MatchError(ContainSubstring("some error")))
+			})
+		})
+	})
+})


### PR DESCRIPTION
I added a new services that can send notifications to Lark group chats.

Lark is a widely used IM tool. It supports creating custom bots in group chats and sending messages via WebHook.
