### PR TITLE
Add thread_id support for discord service

### DIFF
--- a/docs/services/discord.md
+++ b/docs/services/discord.md
@@ -14,6 +14,26 @@ The shoutrrr service URL should look like this:
 
 --8<-- "docs/services/discord/config.md"
 
+## Optional: Sending messages to a specific thread
+
+Discord supports sending messages via webhook to threads. You can target a specific thread by appending
+`?thread_id=<id>` to the end of the url.
+
+!!! info ""
+### Example
+
+```
+discord://<token>@<webhook_id>?thread_id=1234567890123456789
+```
+
+To get the thread ID:
+ - Open a Discord Thread
+ - Right click -> copy link
+ - OR Right click -> copy thread ID (Developer mode turned on in discord settings)
+
+!!! warning ""
+A valid thread_id must is 19 digits long. If extracting from a link don't confuse the channel ID and thread ID.
+
 ## Creating a webhook in Discord
 
 1. Open your channel settings by first clicking on the gear icon next to the name of the channel.

--- a/pkg/services/discord/discord.go
+++ b/pkg/services/discord/discord.go
@@ -126,6 +126,7 @@ func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) e
 
 // CreateAPIURLFromConfig takes a discord config object and creates a post url
 func CreateAPIURLFromConfig(config *Config) string {
+	// Optional queryParams
 	queryParams := ""
     if config.ThreadID != "" {
         queryParams = "?thread_id=" + config.ThreadID

--- a/pkg/services/discord/discord.go
+++ b/pkg/services/discord/discord.go
@@ -126,19 +126,15 @@ func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) e
 
 // CreateAPIURLFromConfig takes a discord config object and creates a post url
 func CreateAPIURLFromConfig(config *Config) string {
-	// Optional queryParams
-	queryParams := ""
+	baseURL := fmt.Sprintf("%s/%s/%s", hookURL, config.WebhookID, config.Token)
+
 	if config.ThreadID != "" {
-		queryParams = "?thread_id=" + config.ThreadID
+		queryParams := url.Values{}
+		queryParams.Set("thread_id", config.ThreadID)
+		return baseURL + "?" + queryParams.Encode()
 	}
 
-	return fmt.Sprintf(
-		"%s/%s/%s%s",
-		hookURL,
-		config.WebhookID,
-		config.Token,
-		queryParams,
-	)
+	return baseURL
 }
 
 func doSend(payload []byte, postURL string) error {

--- a/pkg/services/discord/discord.go
+++ b/pkg/services/discord/discord.go
@@ -128,17 +128,17 @@ func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) e
 func CreateAPIURLFromConfig(config *Config) string {
 	// Optional queryParams
 	queryParams := ""
-    if config.ThreadID != "" {
-        queryParams = "?thread_id=" + config.ThreadID
-    }
+	if config.ThreadID != "" {
+		queryParams = "?thread_id=" + config.ThreadID
+	}
 
-    return fmt.Sprintf(
-        "%s/%s/%s%s",
-        hookURL,
-        config.WebhookID,
-        config.Token,
-        queryParams,
-    )
+	return fmt.Sprintf(
+		"%s/%s/%s%s",
+		hookURL,
+		config.WebhookID,
+		config.Token,
+		queryParams,
+	)
 }
 
 func doSend(payload []byte, postURL string) error {

--- a/pkg/services/discord/discord.go
+++ b/pkg/services/discord/discord.go
@@ -126,11 +126,18 @@ func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) e
 
 // CreateAPIURLFromConfig takes a discord config object and creates a post url
 func CreateAPIURLFromConfig(config *Config) string {
-	return fmt.Sprintf(
-		"%s/%s/%s",
-		hookURL,
-		config.WebhookID,
-		config.Token)
+	queryParams := ""
+    if config.ThreadID != "" {
+        queryParams = "?thread_id=" + config.ThreadID
+    }
+
+    return fmt.Sprintf(
+        "%s/%s/%s%s",
+        hookURL,
+        config.WebhookID,
+        config.Token,
+        queryParams,
+    )
 }
 
 func doSend(payload []byte, postURL string) error {

--- a/pkg/services/discord/discord_config.go
+++ b/pkg/services/discord/discord_config.go
@@ -23,6 +23,7 @@ type Config struct {
 	ColorDebug uint   `key:"colorDebug" default:"0x7b00ab" desc:"The color of the left border for debug messages"   base:"16"`
 	SplitLines bool   `key:"splitLines" default:"Yes"      desc:"Whether to send each line as a separate embedded item"`
 	JSON       bool   `key:"json"       default:"No"       desc:"Whether to send the whole message as the JSON payload instead of using it as the 'content' field"`
+	ThreadID   string `key:"thread_id"  default:""         descridescption:"Optional thread ID for posting into a channel thread instead of directly in a cahnel"`
 }
 
 // LevelColors returns an array of colors with a MessageLevel index

--- a/pkg/services/discord/discord_config.go
+++ b/pkg/services/discord/discord_config.go
@@ -23,7 +23,7 @@ type Config struct {
 	ColorDebug uint   `key:"colorDebug" default:"0x7b00ab" desc:"The color of the left border for debug messages"   base:"16"`
 	SplitLines bool   `key:"splitLines" default:"Yes"      desc:"Whether to send each line as a separate embedded item"`
 	JSON       bool   `key:"json"       default:"No"       desc:"Whether to send the whole message as the JSON payload instead of using it as the 'content' field"`
-	ThreadID   string `key:"thread_id"  default:""         descridescption:"Optional thread ID for posting into a channel thread instead of directly in a cahnel"`
+	ThreadID   string `key:"thread_id"  default:""         desc:"Optional thread ID for posting into a channel thread"`
 }
 
 // LevelColors returns an array of colors with a MessageLevel index

--- a/pkg/services/discord/discord_test.go
+++ b/pkg/services/discord/discord_test.go
@@ -116,6 +116,29 @@ var _ = Describe("the discord service", func() {
 			})
 		})
 	})
+	Describe("creating an API URL", func() {
+		When("given a config without thread ID", func() {
+			It("should create a URL without query parameters", func() {
+				config := &Config{
+					WebhookID: "1",
+					Token:     "dummyToken",
+				}
+				apiURL := CreateAPIURLFromConfig(config)
+				Expect(apiURL).To(Equal("https://discord.com/api/webhooks/1/dummyToken"))
+			})
+		})
+		When("given a config with thread ID", func() {
+			It("should create a URL with thread_id query parameter", func() {
+				config := &Config{
+					WebhookID: "1",
+					Token:     "dummyToken",
+					ThreadID:  "987654321",
+				}
+				apiURL := CreateAPIURLFromConfig(config)
+				Expect(apiURL).To(Equal("https://discord.com/api/webhooks/1/dummyToken?thread_id=987654321"))
+			})
+		})
+	})
 	Describe("creating a json payload", func() {
 		When("given a blank message", func() {
 			When("split lines is enabled", func() {


### PR DESCRIPTION
Adds optional ?= processing when constructing the discord URL and a new param thread_id

I gave it a quick test or two (with leaving the thread ID empty and without). Closes #464 

Thank you!
