### PR TITLE
feat(slack): `splitLines` to send each line as a separate item

### DIFF
--- a/pkg/services/slack/slack.go
+++ b/pkg/services/slack/slack.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/containrrr/shoutrrr/pkg/format"
-	"github.com/containrrr/shoutrrr/pkg/util/jsonclient"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/util/jsonclient"
 
 	"github.com/containrrr/shoutrrr/pkg/services/standard"
 	"github.com/containrrr/shoutrrr/pkg/types"
@@ -52,7 +53,9 @@ func (service *Service) Send(message string, params *types.Params) error {
 // Initialize loads ServiceConfig from configURL and sets logger for this Service
 func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
 	service.Logger.SetLogger(logger)
-	service.config = &Config{}
+	service.config = &Config{
+		SplitLines: true,
+	}
 	service.pkr = format.NewPropKeyResolver(service.config)
 
 	return service.config.setURL(&service.pkr, configURL)

--- a/pkg/services/slack/slack_config.go
+++ b/pkg/services/slack/slack_config.go
@@ -11,13 +11,14 @@ import (
 // Config for the slack service
 type Config struct {
 	standard.EnumlessConfig
-	BotName string `optional:"uses bot default" key:"botname,username" desc:"Bot name"`
-	Icon    string `key:"icon,icon_emoji,icon_url" default:"" optional:"" desc:"Use emoji or URL as icon (based on presence of http(s):// prefix)"`
-	Token   Token  `desc:"API Bot token" url:"user,pass"`
-	Color   string `key:"color" optional:"default border color" desc:"Message left-hand border color"`
-	Title   string `key:"title" optional:"omitted" desc:"Prepended text above the message"`
-	Channel string `url:"host" desc:"Channel to send messages to in Cxxxxxxxxxx format"`
-	ThreadTS string   `key:"thread_ts" optional:"" desc:"ts value of the parent message (to send message as reply in thread)"`
+	BotName    string `optional:"uses bot default" key:"botname,username" desc:"Bot name"`
+	Icon       string `key:"icon,icon_emoji,icon_url" default:"" optional:"" desc:"Use emoji or URL as icon (based on presence of http(s):// prefix)"`
+	Token      Token  `desc:"API Bot token" url:"user,pass"`
+	Color      string `key:"color" optional:"default border color" desc:"Message left-hand border color"`
+	Title      string `key:"title" optional:"omitted" desc:"Prepended text above the message"`
+	Channel    string `url:"host" desc:"Channel to send messages to in Cxxxxxxxxxx format"`
+	ThreadTS   string `key:"thread_ts" optional:"" desc:"ts value of the parent message (to send message as reply in thread)"`
+	SplitLines bool   `key:"splitLines" default:"Yes" desc:"Whether to send each line as a separate embedded item"`
 }
 
 // GetURL returns a URL representation of it's current field values

--- a/pkg/services/slack/slack_json.go
+++ b/pkg/services/slack/slack_json.go
@@ -73,15 +73,22 @@ type APIResponse struct {
 func CreateJSONPayload(config *Config, message string) interface{} {
 
 	var atts []attachment
-	for i, line := range strings.Split(message, "\n") {
-		// When 100 attachments have been reached, append the remaining line to the last
-		// attachment to prevent reaching the slack API limit
-		if i >= 100 {
-			atts[len(atts)-1].Text += "\n" + line
-			continue
+	if config.SplitLines {
+		for i, line := range strings.Split(message, "\n") {
+			// When 100 attachments have been reached, append the remaining line to the last
+			// attachment to prevent reaching the slack API limit
+			if i >= 100 {
+				atts[len(atts)-1].Text += "\n" + line
+				continue
+			}
+			atts = append(atts, attachment{
+				Text:  line,
+				Color: config.Color,
+			})
 		}
+	} else {
 		atts = append(atts, attachment{
-			Text:  line,
+			Text:  message,
 			Color: config.Color,
 		})
 	}


### PR DESCRIPTION
Implements the analogous `splitLines` functionality from Discord configuration (https://github.com/containrrr/shoutrrr/commit/8d401466680c0dbe416efca2d6253e2f965bab1a).

This fixes an issue with multi-line code formatted messages e.g.,:

>```
> URLs: [redacted]
> Message: ```
> a
> b
> c
> `` ` (I added a space here to format the message here correctly.)
> Notification sent
> ```