### PR TITLE
feat: added markdown support for ntfy.sh notifications

### DIFF
--- a/pkg/services/ntfy/ntfy.go
+++ b/pkg/services/ntfy/ntfy.go
@@ -74,6 +74,9 @@ func (service *Service) sendAPI(config *Config, message string) error {
 	if !config.Firebase {
 		headers.Add("Firebase", "no")
 	}
+	if config.Markdown {
+		headers.Add("Markdown", "yes")
+	}
 
 	if err := jsonClient.Post(config.GetAPIURL(), request, &response); err != nil {
 		if jsonClient.ErrorResponse(err, &response) {

--- a/pkg/services/ntfy/ntfy_config.go
+++ b/pkg/services/ntfy/ntfy_config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Icon     string   `key:"icon"        optional:""         desc:"URL to use as notification icon"`
 	Cache    bool     `key:"cache"       default:"yes"       desc:"Cache messages"`
 	Firebase bool     `key:"firebase"    default:"yes"       desc:"Send to firebase"`
+	Markdown bool     `key:"markdown"    default:"no"        desc:"Enable markdown formatting"`
 }
 
 // Enums implements types.ServiceConfig

--- a/pkg/services/ntfy/ntfy_test.go
+++ b/pkg/services/ntfy/ntfy_test.go
@@ -76,7 +76,7 @@ var _ = Describe("the ntfy service", func() {
 		})
 		When("parsing the configuration URL", func() {
 			It("should be identical after de-/serialization", func() {
-				testURL := "ntfy://user:pass@example.com:2225/topic?cache=No&click=CLICK&firebase=No&icon=ICON&priority=Max&scheme=http&title=TITLE"
+				testURL := "ntfy://user:pass@example.com:2225/topic?cache=No&click=CLICK&firebase=No&icon=ICON&markdown=No&priority=Max&scheme=http&title=TITLE"
 				config := &Config{}
 				pkr := format.NewPropKeyResolver(config)
 				Expect(config.setURL(&pkr, testutils.URLMust(testURL))).To(Succeed(), "verifying")
@@ -132,7 +132,7 @@ var _ = Describe("the ntfy service", func() {
 				testutils.TestConfigSetDefaultValues(&Config{})
 
 				testutils.TestConfigGetEnumsCount(&Config{}, 1)
-				testutils.TestConfigGetFieldsCount(&Config{}, 15)
+				testutils.TestConfigGetFieldsCount(&Config{}, 16)
 			})
 		})
 		Describe("the service instance", func() {


### PR DESCRIPTION
Added a `markdown` boolean in the service configuration, which maps to `markdown=yes` in the query URL. This adheres to the [ntfy.sh markdown documentation](https://docs.ntfy.sh/publish/#markdown-formatting)

Fixes #462 
