### PR TITLE
Fix: Matrix password login device reuse

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,17 @@ jobs:
       - name: Build
         run: CGO_ENABLED=0 go build -v .
 
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+
+      - name: Verify Docker
+        run: docker version
+
       - name: Test
         run: CGO_ENABLED=0 go test -v -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Test Matrix Conduit E2E
+        run: CGO_ENABLED=0 SHOUTRRR_MATRIX_CONDUIT_E2E=1 go test -tags conduit_e2e -v ./pkg/services/matrix -run TestConduitE2E
 
       - name: Publish coverage
         uses: codecov/codecov-action@v3

--- a/docs/services/matrix.md
+++ b/docs/services/matrix.md
@@ -18,6 +18,9 @@ flow your server uses, if you can manually retrieve a token, then Shoutrrr can u
 ### Password Login Flow
 
 If a `user` and `password` is supplied, the `m.login.password` login flow is attempted if the server supports it.
+Shoutrrr sends a stable Matrix `device_id` during password login to avoid creating a new Matrix device on every
+initialization. The default device ID is `shoutrrr`; override it with `deviceID=...` if you need separate devices for
+separate Shoutrrr instances using the same account.
 
 ## Rooms
 

--- a/pkg/services/matrix/matrix.go
+++ b/pkg/services/matrix/matrix.go
@@ -31,7 +31,7 @@ func (s *Service) Initialize(configURL *url.URL, logger t.StdLogger) error {
 
 	s.client = newClient(s.config.Host, s.config.DisableTLS, logger)
 	if s.config.User != "" {
-		return s.client.login(s.config.User, s.config.Password)
+		return s.client.login(s.config.User, s.config.Password, s.config.DeviceID)
 	}
 
 	s.client.useToken(s.config.Password)

--- a/pkg/services/matrix/matrix_api.go
+++ b/pkg/services/matrix/matrix_api.go
@@ -7,7 +7,7 @@ type identifierType string
 const (
 	apiLogin       = "/_matrix/client/r0/login"
 	apiRoomJoin    = "/_matrix/client/r0/join/%s"
-	apiSendMessage = "/_matrix/client/r0/rooms/%s/send/m.room.message"
+	apiSendMessage = "/_matrix/client/r0/rooms/%s/send/m.room.message/%s"
 	apiJoinedRooms = "/_matrix/client/r0/joined_rooms"
 
 	contentType = "application/json"
@@ -28,6 +28,7 @@ type apiReqLogin struct {
 	Identifier *identifier `json:"identifier"`
 	Password   string      `json:"password,omitempty"`
 	Token      string      `json:"token,omitempty"`
+	DeviceID   string      `json:"device_id,omitempty"`
 }
 
 type apiResLogin struct {

--- a/pkg/services/matrix/matrix_client.go
+++ b/pkg/services/matrix/matrix_client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 
 	"github.com/containrrr/shoutrrr/pkg/types"
 	"github.com/containrrr/shoutrrr/pkg/util"
@@ -17,6 +18,7 @@ type client struct {
 	apiURL      url.URL
 	accessToken string
 	logger      types.StdLogger
+	txnID       uint64
 }
 
 func newClient(host string, disableTLS bool, logger types.StdLogger) (c *client) {
@@ -46,7 +48,7 @@ func (c *client) useToken(token string) {
 	c.updateAccessToken()
 }
 
-func (c *client) login(user string, password string) error {
+func (c *client) login(user string, password string, deviceID string) error {
 	c.apiURL.RawQuery = ""
 	defer c.updateAccessToken()
 
@@ -60,19 +62,20 @@ func (c *client) login(user string, password string) error {
 		flows = append(flows, string(flow.Type))
 		if flow.Type == flowLoginPassword {
 			c.logf("Using login flow '%v'", flow.Type)
-			return c.loginPassword(user, password)
+			return c.loginPassword(user, password, deviceID)
 		}
 	}
 
 	return fmt.Errorf("none of the server login flows are supported: %v", strings.Join(flows, ", "))
 }
 
-func (c *client) loginPassword(user string, password string) error {
+func (c *client) loginPassword(user string, password string, deviceID string) error {
 	response := apiResLogin{}
 	if err := c.apiPost(apiLogin, apiReqLogin{
 		Type:       flowLoginPassword,
 		Password:   password,
 		Identifier: newUserIdentifier(user),
+		DeviceID:   deviceID,
 	}, &response); err != nil {
 		return fmt.Errorf("failed to log in: %w", err)
 	}
@@ -103,14 +106,16 @@ func (c *client) sendToExplicitRooms(rooms []string, message string) (errors []e
 	for _, room := range rooms {
 		c.logf("Sending message to '%v'...\n", room)
 
-		var roomID string
-		if roomID, err = c.joinRoom(room); err != nil {
-			errors = append(errors, fmt.Errorf("error joining room %v: %w", roomID, err))
-			continue
-		}
+		roomID := room
+		if !strings.HasPrefix(room, "!") {
+			if roomID, err = c.joinRoom(room); err != nil {
+				errors = append(errors, fmt.Errorf("error joining room %v: %w", roomID, err))
+				continue
+			}
 
-		if room != roomID {
-			c.logf("Resolved room alias '%v' to ID '%v'", room, roomID)
+			if room != roomID {
+				c.logf("Resolved room alias '%v' to ID '%v'", room, roomID)
+			}
 		}
 
 		if err := c.sendMessageToRoom(message, roomID); err != nil {
@@ -148,7 +153,7 @@ func (c *client) joinRoom(room string) (roomID string, err error) {
 
 func (c *client) sendMessageToRoom(message string, roomID string) error {
 	resEvent := apiResEvent{}
-	return c.apiPost(fmt.Sprintf(apiSendMessage, roomID), apiReqSend{
+	return c.apiPut(fmt.Sprintf(apiSendMessage, roomID, c.nextTransactionID()), apiReqSend{
 		MsgType: msgTypeText,
 		Body:    message,
 	}, &resEvent)
@@ -187,6 +192,14 @@ func (c *client) apiGet(path string, response interface{}) error {
 }
 
 func (c *client) apiPost(path string, request interface{}, response interface{}) error {
+	return c.apiRequest(http.MethodPost, path, request, response)
+}
+
+func (c *client) apiPut(path string, request interface{}, response interface{}) error {
+	return c.apiRequest(http.MethodPut, path, request, response)
+}
+
+func (c *client) apiRequest(method string, path string, request interface{}, response interface{}) error {
 	c.apiURL.Path = path
 
 	var err error
@@ -198,7 +211,13 @@ func (c *client) apiPost(path string, request interface{}, response interface{})
 	}
 
 	var res *http.Response
-	res, err = http.Post(c.apiURL.String(), contentType, bytes.NewReader(body))
+	req, err := http.NewRequest(method, c.apiURL.String(), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	res, err = http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -222,6 +241,10 @@ func (c *client) apiPost(path string, request interface{}, response interface{})
 	}
 
 	return json.Unmarshal(body, response)
+}
+
+func (c *client) nextTransactionID() string {
+	return fmt.Sprintf("shoutrrr-%d", atomic.AddUint64(&c.txnID, 1))
 }
 
 func (c *client) updateAccessToken() {

--- a/pkg/services/matrix/matrix_conduit_e2e_test.go
+++ b/pkg/services/matrix/matrix_conduit_e2e_test.go
@@ -1,0 +1,247 @@
+//go:build conduit_e2e
+// +build conduit_e2e
+
+package matrix
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConduitE2E(t *testing.T) {
+	if os.Getenv("SHOUTRRR_MATRIX_CONDUIT_E2E") != "1" {
+		t.Skip("set SHOUTRRR_MATRIX_CONDUIT_E2E=1 to run the Conduit e2e test")
+	}
+
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Fatalf("docker is required for Conduit e2e test: %v", err)
+	}
+
+	image := os.Getenv("SHOUTRRR_MATRIX_CONDUIT_IMAGE")
+	if image == "" {
+		image = "docker.io/matrixconduit/matrix-conduit:latest"
+	}
+	port := os.Getenv("SHOUTRRR_MATRIX_CONDUIT_PORT")
+	if port == "" {
+		port = "6167"
+	}
+
+	configPath := filepath.Join(t.TempDir(), "conduit.toml")
+	config := `
+[global]
+server_name = "localhost"
+address = "0.0.0.0"
+port = 6167
+database_backend = "rocksdb"
+database_path = "/var/lib/matrix-conduit"
+allow_registration = true
+allow_federation = false
+trusted_servers = []
+max_request_size = 20000000
+`
+	if err := os.WriteFile(configPath, []byte(config), 0600); err != nil {
+		t.Fatalf("write Conduit config: %v", err)
+	}
+
+	container := fmt.Sprintf("shoutrrr-conduit-e2e-%d", time.Now().UnixNano())
+	runDocker(t, "run", "--rm", "-d",
+		"--name", container,
+		"-p", "127.0.0.1:"+port+":6167",
+		"-v", configPath+":/etc/conduit.toml:ro",
+		"-e", "CONDUIT_CONFIG=/etc/conduit.toml",
+		image)
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "rm", "-f", container).Run()
+	})
+
+	baseURL := "http://127.0.0.1:" + port
+	waitForConduit(t, container, baseURL)
+	user := "shoutrrr"
+	password := "shoutrrr-password"
+	deviceID := "shoutrrr-e2e"
+	registration := conduitRegister(t, baseURL, user, password)
+	roomID := conduitCreateRoom(t, baseURL, registration.AccessToken)
+
+	values := url.Values{}
+	values.Set("disableTLS", "yes")
+	values.Set("rooms", roomID)
+	values.Set("deviceID", deviceID)
+	serviceURL := url.URL{
+		Scheme:   Scheme,
+		Host:     strings.TrimPrefix(baseURL, "http://"),
+		User:     url.UserPassword(user, password),
+		RawQuery: values.Encode(),
+	}
+
+	for i := 0; i < 3; i++ {
+		service := &Service{}
+		if err := service.Initialize(&serviceURL, nil); err != nil {
+			t.Fatalf("initialize Matrix service: %v", err)
+		}
+		if err := service.Send(fmt.Sprintf("Conduit e2e test %d", i+1), nil); err != nil {
+			t.Fatalf("send Matrix message: %v", err)
+		}
+	}
+
+	devices := conduitDevices(t, baseURL, registration.AccessToken)
+	count := 0
+	for _, device := range devices.Devices {
+		if device.DeviceID == deviceID {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one Matrix device with ID %q, got %d; devices: %+v", deviceID, count, devices.Devices)
+	}
+}
+
+func runDocker(t *testing.T, args ...string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func waitForConduit(t *testing.T, container string, baseURL string) {
+	t.Helper()
+
+	deadline := time.Now().Add(45 * time.Second)
+	for time.Now().Before(deadline) {
+		res, err := http.Get(baseURL + "/_matrix/client/versions")
+		if err == nil {
+			_ = res.Body.Close()
+			if res.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for Conduit container %s at %s\n%s", container, baseURL, dockerLogs(container))
+}
+
+func dockerLogs(container string) string {
+	cmd := exec.Command("docker", "logs", container)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Sprintf("docker logs failed: %v\n%s", err, output)
+	}
+	return string(output)
+}
+
+type conduitRegisterResponse struct {
+	AccessToken string `json:"access_token"`
+	DeviceID    string `json:"device_id"`
+	UserID      string `json:"user_id"`
+}
+
+func conduitRegister(t *testing.T, baseURL string, user string, password string) conduitRegisterResponse {
+	t.Helper()
+
+	request := map[string]interface{}{
+		"username": user,
+		"password": password,
+		"auth": map[string]string{
+			"type": "m.login.dummy",
+		},
+	}
+
+	response := conduitRegisterResponse{}
+	doMatrixJSON(t, http.MethodPost, baseURL+"/_matrix/client/r0/register?kind=user", "", request, &response)
+	if response.AccessToken == "" {
+		t.Fatalf("Conduit registration did not return an access token: %+v", response)
+	}
+	return response
+}
+
+func conduitCreateRoom(t *testing.T, baseURL string, accessToken string) string {
+	t.Helper()
+
+	request := map[string]string{
+		"name":   "Shoutrrr Conduit E2E",
+		"preset": "private_chat",
+	}
+
+	response := struct {
+		RoomID string `json:"room_id"`
+	}{}
+	doMatrixJSON(t, http.MethodPost, baseURL+"/_matrix/client/r0/createRoom", accessToken, request, &response)
+	if response.RoomID == "" {
+		t.Fatalf("Conduit createRoom did not return a room ID: %+v", response)
+	}
+	return response.RoomID
+}
+
+type conduitDevicesResponse struct {
+	Devices []struct {
+		DeviceID string `json:"device_id"`
+	} `json:"devices"`
+}
+
+func conduitDevices(t *testing.T, baseURL string, accessToken string) conduitDevicesResponse {
+	t.Helper()
+
+	response := conduitDevicesResponse{}
+	doMatrixJSON(t, http.MethodGet, baseURL+"/_matrix/client/r0/devices", accessToken, nil, &response)
+	return response
+}
+
+func doMatrixJSON(t *testing.T, method string, endpoint string, accessToken string, request interface{}, response interface{}) {
+	t.Helper()
+
+	var body io.Reader
+	if request != nil {
+		data, err := json.Marshal(request)
+		if err != nil {
+			t.Fatalf("marshal Matrix request: %v", err)
+		}
+		body = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, endpoint, body)
+	if err != nil {
+		t.Fatalf("create Matrix request: %v", err)
+	}
+	if request != nil {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("perform Matrix request %s %s: %v", method, endpoint, err)
+	}
+	defer res.Body.Close()
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read Matrix response: %v", err)
+	}
+	if res.StatusCode >= 400 {
+		t.Fatalf("Matrix request %s %s failed with %s: %s", method, endpoint, res.Status, data)
+	}
+	if response != nil && len(data) > 0 {
+		if err := json.Unmarshal(data, response); err != nil {
+			t.Fatalf("decode Matrix response: %v\n%s", err, data)
+		}
+	}
+}

--- a/pkg/services/matrix/matrix_config.go
+++ b/pkg/services/matrix/matrix_config.go
@@ -8,6 +8,8 @@ import (
 	t "github.com/containrrr/shoutrrr/pkg/types"
 )
 
+const defaultDeviceID = "shoutrrr"
+
 // Config is the configuration for the matrix service
 type Config struct {
 	standard.EnumlessConfig
@@ -15,6 +17,7 @@ type Config struct {
 	User       string   `optional:"" url:"user" desc:"Username or empty when using access token"`
 	Password   string   `url:"password" desc:"Password or access token"`
 	DisableTLS bool     `key:"disableTLS" default:"No"`
+	DeviceID   string   `key:"deviceID" default:"shoutrrr" desc:"Device ID for password login; keeps Matrix homeservers from creating a new device for each login"`
 	Host       string   `url:"host"`
 	Rooms      []string `key:"rooms,room" optional:"" desc:"Room aliases, or with ! prefix, room IDs"`
 	Title      string   `key:"title" default:""`
@@ -45,6 +48,7 @@ func (c *Config) getURL(resolver t.ConfigQueryResolver) *url.URL {
 
 func (c *Config) setURL(resolver t.ConfigQueryResolver, configURL *url.URL) error {
 
+	c.DeviceID = defaultDeviceID
 	c.User = configURL.User.Username()
 	password, _ := configURL.User.Password()
 	c.Password = password

--- a/pkg/services/matrix/matrix_test.go
+++ b/pkg/services/matrix/matrix_test.go
@@ -1,7 +1,10 @@
 package matrix
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 
 	"github.com/containrrr/shoutrrr/internal/testutils"
@@ -120,6 +123,18 @@ var _ = Describe("the matrix service", func() {
 				err = service.Send("Test message", nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
+			When("sending to a room ID", func() {
+				It("should not try to join the room", func() {
+					setupMockResponders()
+					serviceURL, _ := url.Parse("matrix://user:pass@mockserver?rooms=!room:mockserver")
+					err := service.Initialize(serviceURL, logger)
+					Expect(err).NotTo(HaveOccurred())
+
+					err = service.Send("Test message", nil)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(httpmock.GetCallCountInfo()["POST https://mockserver/_matrix/client/r0/join/%21room:mockserver?access_token=TOKEN"]).To(Equal(0))
+				})
+			})
 			When("sending to one room fails", func() {
 				It("should report one error", func() {
 					setupMockResponders()
@@ -135,6 +150,30 @@ var _ = Describe("the matrix service", func() {
 
 		})
 
+		When("logging in with a password", func() {
+			It("should reuse a stable device ID by default", func() {
+				const mockServer = "https://mockserver"
+				httpmock.RegisterResponder(
+					"GET",
+					mockServer+apiLogin,
+					httpmock.NewStringResponder(200, `{"flows": [ { "type": "m.login.password" } ] }`))
+
+				httpmock.RegisterResponder("POST", mockServer+apiLogin, func(req *http.Request) (*http.Response, error) {
+					body, err := ioutil.ReadAll(req.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					login := apiReqLogin{}
+					Expect(json.Unmarshal(body, &login)).To(Succeed())
+					Expect(login.DeviceID).To(Equal(defaultDeviceID))
+
+					return httpmock.NewStringResponse(200, `{ "access_token": "TOKEN", "home_server": "mockserver", "user_id": "test:mockerserver", "device_id": "shoutrrr" }`), nil
+				})
+
+				serviceURL, _ := url.Parse("matrix://user:pass@mockserver")
+				Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+			})
+		})
+
 		AfterEach(func() {
 			httpmock.DeactivateAndReset()
 		})
@@ -145,7 +184,7 @@ var _ = Describe("the matrix service", func() {
 		testutils.TestConfigSetInvalidQueryValue(&Config{}, "matrix://user:pass@host/?foo=bar")
 
 		testutils.TestConfigGetEnumsCount(&Config{}, 0)
-		testutils.TestConfigGetFieldsCount(&Config{}, 4)
+		testutils.TestConfigGetFieldsCount(&Config{}, 5)
 	})
 })
 
@@ -167,13 +206,13 @@ func setupMockResponders() {
 		mockServer+apiJoinedRooms,
 		httpmock.NewStringResponder(200, `{ "joined_rooms": [ "!room:mockserver" ] }`))
 
-	httpmock.RegisterResponder("POST", mockServer+fmt.Sprintf(apiSendMessage, "%21room:mockserver"),
+	httpmock.RegisterResponder("PUT", mockServer+fmt.Sprintf(apiSendMessage, "%21room:mockserver", "shoutrrr-1"),
 		httpmock.NewJsonResponderOrPanic(200, apiResEvent{EventID: "7"}))
 
-	httpmock.RegisterResponder("POST", mockServer+fmt.Sprintf(apiSendMessage, "1"),
+	httpmock.RegisterResponder("PUT", mockServer+fmt.Sprintf(apiSendMessage, "1", "shoutrrr-1"),
 		httpmock.NewJsonResponderOrPanic(200, apiResEvent{EventID: "8"}))
 
-	httpmock.RegisterResponder("POST", mockServer+fmt.Sprintf(apiSendMessage, "2"),
+	httpmock.RegisterResponder("PUT", mockServer+fmt.Sprintf(apiSendMessage, "2", "shoutrrr-2"),
 		httpmock.NewJsonResponderOrPanic(200, apiResEvent{EventID: "9"}))
 
 	httpmock.RegisterResponder("POST", mockServer+fmt.Sprintf(apiRoomJoin, "%23room1"),


### PR DESCRIPTION
## Summary
- Reuse a stable Matrix device ID for password logins.
- Send Matrix messages with PUT and transaction IDs.
- Add a Docker-backed Conduit e2e test in CI.

Closes #438.
Closes #477.
Closes #415.