### PR TITLE
Fix Telegram transport error handling

### DIFF
--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -43,6 +43,7 @@ var serviceURLs = map[string]string{
 var serviceResponses = map[string]string{
 	"pushbullet": `{"created": 0}`,
 	"gotify":     `{"id": 0}`,
+	"telegram":   `{"ok":true,"result":{"message_id":1,"text":"test"}}`,
 }
 
 var logger = log.New(GinkgoWriter, "Test", log.LstdFlags)

--- a/pkg/services/telegram/telegram_client.go
+++ b/pkg/services/telegram/telegram_client.go
@@ -21,7 +21,7 @@ func (c *Client) GetBotInfo() (*User, error) {
 	err := jsonclient.Get(c.apiURL("getMe"), response)
 
 	if !response.OK {
-		return nil, GetErrorResponse(jsonclient.ErrorBody(err))
+		return nil, GetResponseError(err)
 	}
 
 	return &response.Result, nil
@@ -40,7 +40,7 @@ func (c *Client) GetUpdates(offset int, limit int, timeout int, allowedUpdates [
 	err := jsonclient.Post(c.apiURL("getUpdates"), request, response)
 
 	if !response.OK {
-		return nil, GetErrorResponse(jsonclient.ErrorBody(err))
+		return nil, GetResponseError(err)
 	}
 
 	return response.Result, nil
@@ -53,7 +53,7 @@ func (c *Client) SendMessage(message *SendMessagePayload) (*Message, error) {
 	err := jsonclient.Post(c.apiURL("sendMessage"), message, response)
 
 	if !response.OK {
-		return nil, GetErrorResponse(jsonclient.ErrorBody(err))
+		return nil, GetResponseError(err)
 	}
 
 	return response.Result, nil
@@ -66,4 +66,12 @@ func GetErrorResponse(body string) error {
 		return response
 	}
 	return nil
+}
+
+// GetResponseError preserves Telegram API errors, falling back to transport errors.
+func GetResponseError(err error) error {
+	if responseErr := GetErrorResponse(jsonclient.ErrorBody(err)); responseErr != nil {
+		return responseErr
+	}
+	return err
 }

--- a/pkg/services/telegram/telegram_test.go
+++ b/pkg/services/telegram/telegram_test.go
@@ -1,6 +1,7 @@
 package telegram_test
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -141,10 +142,32 @@ var _ = Describe("the telegram service", func() {
 			err = telegram.Initialize(serviceURL, logger)
 			Expect(err).NotTo(HaveOccurred())
 
-			setupResponder("sendMessage", telegram.GetConfig().Token, 200, "")
+			setupResponder("sendMessage", telegram.GetConfig().Token, 200, `{"ok":true,"result":{"message_id":1,"text":"Message"}}`)
 
 			err = telegram.Send("Message", nil)
 			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should report transport errors", func() {
+			serviceURL, _ := url.Parse("telegram://12345:mock-token@telegram/?chats=channel-1")
+			err = telegram.Initialize(serviceURL, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			setupErrorResponder("sendMessage", telegram.GetConfig().Token, errors.New("dummy transport error"))
+
+			err = telegram.Send("Message", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("dummy transport error"))
+		})
+		It("should report Telegram API errors", func() {
+			serviceURL, _ := url.Parse("telegram://12345:mock-token@telegram/?chats=channel-1")
+			err = telegram.Initialize(serviceURL, logger)
+			Expect(err).NotTo(HaveOccurred())
+
+			setupResponder("sendMessage", telegram.GetConfig().Token, 401, `{"ok":false,"error_code":401,"description":"Unauthorized"}`)
+
+			err = telegram.Send("Message", nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Unauthorized"))
 		})
 
 	})
@@ -170,4 +193,9 @@ func expectErrorAndEmptyObject(telegram *Service, rawURL string, logger *log.Log
 func setupResponder(endpoint string, token string, code int, body string) {
 	targetUrl := fmt.Sprintf("https://api.telegram.org/bot%s/%s", token, endpoint)
 	httpmock.RegisterResponder("POST", targetUrl, httpmock.NewStringResponder(code, body))
+}
+
+func setupErrorResponder(endpoint string, token string, err error) {
+	targetUrl := fmt.Sprintf("https://api.telegram.org/bot%s/%s", token, endpoint)
+	httpmock.RegisterResponder("POST", targetUrl, httpmock.NewErrorResponder(err))
 }


### PR DESCRIPTION
## Summary
- Return Telegram HTTP transport errors instead of reporting success.
- Preserve Telegram API error responses.
- Add regression coverage for transport and API failures.

Closes #473.