### PR TITLE
fix: preserve service ports in Rocket.Chat and Zulip

### DIFF
--- a/pkg/services/rocketchat/rocketchat_config.go
+++ b/pkg/services/rocketchat/rocketchat_config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/containrrr/shoutrrr/pkg/types"
+	"net"
 	"net/url"
 	"strings"
 
@@ -23,9 +24,13 @@ type Config struct {
 
 // GetURL returns a URL representation of it's current field values
 func (config *Config) GetURL() *url.URL {
+	host := config.Host
+	if config.Port != "" {
+		host = net.JoinHostPort(config.Host, config.Port)
+	}
 
 	u := &url.URL{
-		Host:       fmt.Sprintf("%s:%v", config.Host, config.Port),
+		Host:       host,
 		Path:       fmt.Sprintf("%s/%s", config.TokenA, config.TokenB),
 		Scheme:     Scheme,
 		ForceQuery: false,

--- a/pkg/services/rocketchat/rocketchat_test.go
+++ b/pkg/services/rocketchat/rocketchat_test.go
@@ -1,12 +1,16 @@
 package rocketchat
 
 import (
+	"errors"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"testing"
 
 	"github.com/containrrr/shoutrrr/internal/testutils"
 	"github.com/containrrr/shoutrrr/pkg/types"
+	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -61,6 +65,20 @@ var _ = Describe("the rocketchat service", func() {
 			It("should not set channel or username", func() {
 				Expect(config.Channel).To(BeEmpty())
 				Expect(config.UserName).To(BeEmpty())
+			})
+			It("should generate a URL without an empty port", func() {
+				Expect(config.GetURL().String()).To(Equal("rocketchat://rocketchat.my-domain.com/tokenA/tokenB"))
+			})
+		})
+		When("generating a config object with a port", func() {
+			rocketchatURL, _ := url.Parse("rocketchat://rocketchat.my-domain.com:5055/tokenA/tokenB")
+			config := &Config{}
+			err := config.SetURL(rocketchatURL)
+			It("should not have caused an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should preserve the port in the generated URL", func() {
+				Expect(config.GetURL().String()).To(Equal("rocketchat://rocketchat.my-domain.com:5055/tokenA/tokenB"))
 			})
 		})
 		When("generating a new config with url, that has no token", func() {
@@ -129,6 +147,14 @@ var _ = Describe("the rocketchat service", func() {
 		})
 	})
 	Describe("Sending messages", func() {
+		BeforeEach(func() {
+			httpmock.Activate()
+		})
+
+		AfterEach(func() {
+			httpmock.DeactivateAndReset()
+		})
+
 		When("sending a message completely without parameters", func() {
 			rocketchatURL, _ := url.Parse("rocketchat://rocketchat.my-domain.com/tokenA/tokenB")
 			config := &Config{}
@@ -185,6 +211,64 @@ var _ = Describe("the rocketchat service", func() {
 				config := &Config{}
 				config.SetURL(rocketchatURL)
 				Expect(config.Channel).To(ContainSubstring("#testChannel"))
+			})
+		})
+		When("the webhook accepts the notification", func() {
+			It("should post the expected JSON payload", func() {
+				serviceURL, _ := url.Parse("rocketchat://testUserName@rocketchat.my-domain.com/tokenA/tokenB/testChannel")
+				hookURL := "https://rocketchat.my-domain.com/hooks/tokenA/tokenB"
+
+				service := &Service{}
+				err := service.Initialize(serviceURL, testutils.TestLogger())
+				Expect(err).NotTo(HaveOccurred())
+
+				httpmock.RegisterResponder(http.MethodPost, hookURL, func(req *http.Request) (*http.Response, error) {
+					body, err := io.ReadAll(req.Body)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(req.Header.Get("Content-Type")).To(Equal("application/json"))
+					Expect(string(body)).To(MatchJSON(`{
+						"text": "this is a message",
+						"username": "testUserName",
+						"channel": "#testChannel"
+					}`))
+
+					return httpmock.NewStringResponse(http.StatusOK, ""), nil
+				})
+
+				err = service.Send("this is a message", nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("the webhook rejects the notification", func() {
+			It("should include the response body in the error", func() {
+				serviceURL, _ := url.Parse("rocketchat://rocketchat.my-domain.com/tokenA/tokenB")
+				hookURL := "https://rocketchat.my-domain.com/hooks/tokenA/tokenB"
+
+				service := &Service{}
+				err := service.Initialize(serviceURL, testutils.TestLogger())
+				Expect(err).NotTo(HaveOccurred())
+
+				httpmock.RegisterResponder(http.MethodPost, hookURL, httpmock.NewStringResponder(http.StatusBadRequest, "bad payload"))
+
+				err = service.Send("this is a message", nil)
+				Expect(err).To(MatchError("notification failed: 400 bad payload"))
+			})
+		})
+		When("the webhook cannot be reached", func() {
+			It("should report the transport error with host and port context", func() {
+				serviceURL, _ := url.Parse("rocketchat://rocketchat.my-domain.com:5055/tokenA/tokenB")
+				hookURL := "https://rocketchat.my-domain.com:5055/hooks/tokenA/tokenB"
+
+				service := &Service{}
+				err := service.Initialize(serviceURL, testutils.TestLogger())
+				Expect(err).NotTo(HaveOccurred())
+
+				httpmock.RegisterResponder(http.MethodPost, hookURL, httpmock.NewErrorResponder(errors.New("network down")))
+
+				err = service.Send("this is a message", nil)
+				Expect(err).To(MatchError(ContainSubstring("network down")))
+				Expect(err).To(MatchError(ContainSubstring("HOST: rocketchat.my-domain.com")))
+				Expect(err).To(MatchError(ContainSubstring("PORT: 5055")))
 			})
 		})
 	})

--- a/pkg/services/zulip/zulip_config.go
+++ b/pkg/services/zulip/zulip_config.go
@@ -65,7 +65,7 @@ func (config *Config) setURL(_ types.ConfigQueryResolver, serviceURL *url.URL) e
 		return errors.New(string(MissingAPIKey))
 	}
 
-	config.Host = serviceURL.Hostname()
+	config.Host = serviceURL.Host
 
 	if config.Host == "" {
 		return errors.New(string(MissingHost))

--- a/pkg/services/zulip/zulip_test.go
+++ b/pkg/services/zulip/zulip_test.go
@@ -1,9 +1,14 @@
 package zulip_test
 
 import (
+	"errors"
 	"github.com/containrrr/shoutrrr/internal/testutils"
 	"github.com/containrrr/shoutrrr/pkg/services/zulip"
 	. "github.com/containrrr/shoutrrr/pkg/services/zulip"
+	"github.com/containrrr/shoutrrr/pkg/types"
+	"github.com/jarcoal/httpmock"
+	"io"
+	"net/http"
 
 	"net/url"
 	"os"
@@ -147,6 +152,121 @@ var _ = Describe("the zulip service", func() {
 				}
 				url := config.GetURL()
 				Expect(url.String()).To(Equal("zulip://bot-name%40zulipchat.com:correcthorsebatterystable@example.zulipchat.com?stream=foo"))
+			})
+		})
+		When("given a service url with a non-standard port", func() {
+			It("should preserve the port", func() {
+				zulipURL, err := url.Parse("zulip://bot-name%40zulipchat.com:correcthorsebatterystable@example.zulipchat.com:8443?stream=foo&topic=bar")
+				Expect(err).NotTo(HaveOccurred())
+				serviceConfig, err := CreateConfigFromURL(zulipURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(serviceConfig.Host).To(Equal("example.zulipchat.com:8443"))
+				Expect(serviceConfig.GetURL().String()).To(Equal("zulip://bot-name%40zulipchat.com:correcthorsebatterystable@example.zulipchat.com:8443?stream=foo&topic=bar"))
+			})
+		})
+	})
+	Describe("sending messages", func() {
+		const apiURL = "https://bot-name%40zulipchat.com:correcthorsebatterystable@example.zulipchat.com/api/v1/messages"
+
+		BeforeEach(func() {
+			httpmock.Activate()
+		})
+
+		AfterEach(func() {
+			httpmock.DeactivateAndReset()
+		})
+
+		When("the topic is too long", func() {
+			It("should return an error before posting", func() {
+				zulipURL, err := url.Parse("zulip://bot-name%40zulipchat.com:correcthorsebatterystable@example.zulipchat.com?stream=foo&topic=abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi")
+				Expect(err).NotTo(HaveOccurred())
+
+				service := &Service{}
+				err = service.Initialize(zulipURL, testutils.TestLogger())
+				Expect(err).NotTo(HaveOccurred())
+
+				err = service.Send("This is a message", nil)
+				Expect(err).To(MatchError("topic exceeds max length (60 characters): was 61 characters"))
+				Expect(httpmock.GetTotalCallCount()).To(Equal(0))
+			})
+		})
+
+		When("the message is too large", func() {
+			It("should return an error before posting", func() {
+				zulipURL, err := url.Parse("zulip://bot-name%40zulipchat.com:correcthorsebatterystable@example.zulipchat.com?stream=foo&topic=bar")
+				Expect(err).NotTo(HaveOccurred())
+
+				service := &Service{}
+				err = service.Initialize(zulipURL, testutils.TestLogger())
+				Expect(err).NotTo(HaveOccurred())
+
+				err = service.Send(string(make([]byte, 10001)), nil)
+				Expect(err).To(MatchError("message exceeds max size (10000 bytes): was 10001 bytes"))
+				Expect(httpmock.GetTotalCallCount()).To(Equal(0))
+			})
+		})
+
+		When("send-time params override stream and topic", func() {
+			It("should post the overridden form values", func() {
+				zulipURL, err := url.Parse("zulip://bot-name%40zulipchat.com:correcthorsebatterystable@example.zulipchat.com?stream=foo&topic=bar")
+				Expect(err).NotTo(HaveOccurred())
+
+				service := &Service{}
+				err = service.Initialize(zulipURL, testutils.TestLogger())
+				Expect(err).NotTo(HaveOccurred())
+
+				httpmock.RegisterResponder(http.MethodPost, apiURL, func(req *http.Request) (*http.Response, error) {
+					body, err := io.ReadAll(req.Body)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(req.Header.Get("Content-Type")).To(Equal("application/x-www-form-urlencoded"))
+
+					form, err := url.ParseQuery(string(body))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(form.Get("type")).To(Equal("stream"))
+					Expect(form.Get("to")).To(Equal("overridden-stream"))
+					Expect(form.Get("topic")).To(Equal("overridden-topic"))
+					Expect(form.Get("content")).To(Equal("This is a message"))
+
+					return httpmock.NewStringResponse(http.StatusOK, ""), nil
+				})
+
+				params := types.Params{"stream": "overridden-stream", "topic": "overridden-topic"}
+				err = service.Send("This is a message", &params)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		When("the Zulip API rejects the notification", func() {
+			It("should report the response status", func() {
+				zulipURL, err := url.Parse("zulip://bot-name%40zulipchat.com:correcthorsebatterystable@example.zulipchat.com?stream=foo&topic=bar")
+				Expect(err).NotTo(HaveOccurred())
+
+				service := &Service{}
+				err = service.Initialize(zulipURL, testutils.TestLogger())
+				Expect(err).NotTo(HaveOccurred())
+
+				httpmock.RegisterResponder(http.MethodPost, apiURL, httpmock.NewStringResponder(http.StatusBadRequest, "bad payload"))
+
+				err = service.Send("This is a message", nil)
+				Expect(err).To(MatchError("failed to send zulip message: response status code 400 Bad Request"))
+			})
+		})
+
+		When("the Zulip API cannot be reached", func() {
+			It("should report the transport error", func() {
+				zulipURL, err := url.Parse("zulip://bot-name%40zulipchat.com:correcthorsebatterystable@example.zulipchat.com?stream=foo&topic=bar")
+				Expect(err).NotTo(HaveOccurred())
+
+				service := &Service{}
+				err = service.Initialize(zulipURL, testutils.TestLogger())
+				Expect(err).NotTo(HaveOccurred())
+
+				httpmock.RegisterResponder(http.MethodPost, apiURL, httpmock.NewErrorResponder(errors.New("network down")))
+
+				err = service.Send("This is a message", nil)
+				Expect(err).To(MatchError(ContainSubstring("failed to send zulip message")))
+				Expect(err).To(MatchError(ContainSubstring("network down")))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary
- Preserve Rocket.Chat ports when serializing service URLs, without emitting an empty port when none is configured
- Preserve Zulip non-standard ports when parsing service URLs
- Add mocked send-path coverage for Rocket.Chat and Zulip success, HTTP error, transport error, and validation paths

## Related issues
- No matching open Rocket.Chat/Zulip port issue found to auto-close. #264 mentions Rocket.Chat, but it is about self-signed certificates and is not fixed by this PR.

## Tests
- go test -cover ./pkg/services/rocketchat ./pkg/services/zulip
- go test ./...