### PR TITLE
fix(mattermost): preserve webhook ports

### DIFF
--- a/pkg/services/mattermost/mattermost_config.go
+++ b/pkg/services/mattermost/mattermost_config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containrrr/shoutrrr/pkg/types"
 )
 
-//Config object holding all information
+// Config object holding all information
 type Config struct {
 	standard.EnumlessConfig
 	UserName string `url:"user" optional:"" desc:"Override webhook user"`
@@ -50,7 +50,7 @@ func (config *Config) SetURL(url *url.URL) error {
 
 func (config *Config) setURL(resolver types.ConfigQueryResolver, serviceURL *url.URL) error {
 
-	config.Host = serviceURL.Hostname()
+	config.Host = serviceURL.Host
 	if serviceURL.Path == "" || serviceURL.Path == "/" {
 		return errors.New(string(NotEnoughArguments))
 	}
@@ -77,7 +77,7 @@ func (config *Config) setURL(resolver types.ConfigQueryResolver, serviceURL *url
 	return nil
 }
 
-//ErrorMessage for error events within the mattermost service
+// ErrorMessage for error events within the mattermost service
 type ErrorMessage string
 
 const (

--- a/pkg/services/mattermost/mattermost_test.go
+++ b/pkg/services/mattermost/mattermost_test.go
@@ -62,6 +62,20 @@ var _ = Describe("the mattermost service", func() {
 				Expect(config.UserName).To(BeEmpty())
 			})
 		})
+		When("generating a config object with a port", func() {
+			mattermostURL, _ := url.Parse("mattermost://mattermost.my-domain.com:8065/thisshouldbeanapitoken")
+			config := &Config{}
+			err := config.SetURL(mattermostURL)
+			It("should not have caused an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should preserve the port", func() {
+				Expect(config.Host).To(Equal("mattermost.my-domain.com:8065"))
+			})
+			It("should preserve the port in the generated URL", func() {
+				Expect(config.GetURL().String()).To(Equal("mattermost://mattermost.my-domain.com:8065/thisshouldbeanapitoken"))
+			})
+		})
 		When("generating a new config with url, that has no token", func() {
 			mattermostURL, _ := url.Parse("mattermost://mattermost.my-domain.com")
 			config := &Config{}
@@ -164,6 +178,15 @@ var _ = Describe("the mattermost service", func() {
 				Expect(string(json)).To(Equal("{\"text\":\"this is a message\"}"))
 			})
 		})
+		When("sending to a URL with a port", func() {
+			mattermostURL, _ := url.Parse("mattermost://mattermost.my-domain.com:8065/thisshouldbeanapitoken")
+			config := &Config{}
+			Expect(config.SetURL(mattermostURL)).To(Succeed())
+			It("should generate the correct URL including the port", func() {
+				generatedURL := buildURL(config)
+				Expect(generatedURL).To(Equal("https://mattermost.my-domain.com:8065/hooks/thisshouldbeanapitoken"))
+			})
+		})
 		When("sending a message with pre set username and channel", func() {
 			mattermostURL, _ := url.Parse("mattermost://testUserName@mattermost.my-domain.com/thisshouldbeanapitoken/testChannel")
 			config := &Config{}
@@ -261,6 +284,17 @@ var _ = Describe("the mattermost service", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			httpmock.RegisterResponder("POST", "https://mattermost.host/hooks/token", httpmock.NewStringResponder(200, ``))
+
+			err = service.Send("Message", nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should post to the configured port", func() {
+			serviceURL := testutils.URLMust("mattermost://mattermost.host:8065/token")
+			service := Service{}
+			err = service.Initialize(serviceURL, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			httpmock.RegisterResponder("POST", "https://mattermost.host:8065/hooks/token", httpmock.NewStringResponder(200, ``))
 
 			err = service.Send("Message", nil)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary
- Preserve non-standard ports when parsing Mattermost service URLs
- Add regression coverage for URL serialization, webhook URL construction, and mocked sends to configured ports

Fixes #447

## Tests
- go test -cover ./pkg/services/mattermost
- go test ./...