### PR TITLE
Discord: handle splitLines when set as message param

### DIFF
--- a/pkg/services/discord/discord.go
+++ b/pkg/services/discord/discord.go
@@ -36,11 +36,17 @@ const (
 func (service *Service) Send(message string, params *types.Params) error {
 	var firstErr error
 
+	splitLines := service.config.SplitLines
+	rawSplitLines, ok := (*params)["splitLines"]
+	if ok {
+		splitLines, _ = format.ParseBool(rawSplitLines, service.config.SplitLines)
+	}
+
 	if service.config.JSON {
 		postURL := CreateAPIURLFromConfig(service.config)
 		firstErr = doSend([]byte(message), postURL)
 	} else {
-		batches := CreateItemsFromPlain(message, service.config.SplitLines)
+		batches := CreateItemsFromPlain(message, splitLines)
 		for _, items := range batches {
 			if err := service.sendItems(items, params); err != nil {
 				service.Log(err)


### PR DESCRIPTION
Solves #396

While `splitLines` was allowed as both message and service parameter, `Send` was calling `CreateItemsFromPlain` based on `service.config.SplitLines`. This meant that per-message setting was impossible and forced users to set it in URI (which requires proper URI parsing).

Introduced change to check if `splitLines` is set as message param and if so, parse as boolean overriding `service.config.SplitLines` for this message only.

<img width="704" height="888" alt="CleanShot 2026-05-18 at 20 27 12" src="https://github.com/user-attachments/assets/f903c7f8-b602-4c6f-ab47-ddc092ea785a" />