### PR TITLE
Guard resp.Body.Close against a nil http.Response

### DIFF
--- a/pkg/services/googlechat/googlechat.go
+++ b/pkg/services/googlechat/googlechat.go
@@ -45,8 +45,9 @@ func (service *Service) Send(message string, _ *types.Params) error {
 	if err != nil {
 		return fmt.Errorf("failed to send notification to Google Chat: %s", err)
 	}
-
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("Google Chat API notification returned %d HTTP status code", resp.StatusCode)

--- a/pkg/services/opsgenie/opsgenie.go
+++ b/pkg/services/opsgenie/opsgenie.go
@@ -42,7 +42,9 @@ func (service *Service) sendAlert(url string, apiKey string, payload AlertPayloa
 	if err != nil {
 		return fmt.Errorf("failed to send notification to OpsGenie: %s", err)
 	}
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
`http.Post` and `http.DefaultClient.Do` return a nil `*http.Response` alongside the error when the request never completes (DNS failure, connection refused, timeout), so the deferred `resp.Body.Close()` dereferences a nil pointer and panics instead of surfacing the send error. The OpsGenie and Google Chat senders now close the body only when `resp` is non-nil.