### PR TITLE
Add Pinglet Support

### DIFF
--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -15,6 +15,7 @@ Click on the service for a more thorough explanation. <!-- @formatter:off -->
 | [Matrix](./matrix.md)             | *matrix://__`username`__:__`password`__@__`host`__:__`port`__/[?rooms=__`!roomID1`__[,__`roomAlias2`__]]*                                       |
 | [Ntfy](./ntfy.md)                 | *ntfy://__`username`__:__`password`__@ntfy.sh/__`topic`__*                                                                                      |
 | [OpsGenie](./opsgenie.md)         | *opsgenie://__`host`__/token?responders=__`responder1`__[,__`responder2`__]*                                                                    |
+| [Pinglet](./pinglet.md)           | *pinglet://__`token`__@__`host`__/__`namespace`__/__`topic`__*                                                                                  |
 | [Pushbullet](./pushbullet.md)     | *pushbullet://__`api-token`__[/__`device`__/#__`channel`__/__`email`__]*                                                                        |
 | [Pushover](./pushover.md)         | *pushover://shoutrrr:__`apiToken`__@__`userKey`__/?devices=__`device1`__[,__`device2`__, ...]*                                                  |
 | [Rocketchat](./rocketchat.md)     | *rocketchat://[__`username`__@]__`rocketchat-host`__/__`token`__[/__`channel`&#124;`@recipient`__]*                                             |

--- a/docs/services/pinglet.md
+++ b/docs/services/pinglet.md
@@ -1,0 +1,20 @@
+# Pinglet
+
+Upstream docs: https://pinglet.co.uk
+
+Pinglet delivers notifications to a topic within a namespace via a simple
+authenticated POST. Topics are auto-created on the first publish.
+
+## URL Format
+
+*pinglet://__`token`__@__`host`__/__`namespace`__/__`topic`__*
+
+Use the `pinglet://` scheme (or set `scheme=http`) for an insecure endpoint; the
+default `scheme=https` posts over TLS.
+
+Badges (rendered as pills on the notification card, up to 3) and metadata (shown
+on the detail sheet) are passed as comma-separated key/value pairs:
+
+*pinglet://__`token`__@__`host`__/__`namespace`__/__`topic`__?priority=urgent&badges=Host:web-1,CPU:95%25&data=region:eu-west*
+
+--8<-- "docs/services/pinglet/config.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Matrix: 'services/matrix.md'
       - Ntfy: 'services/ntfy.md'
       - OpsGenie: 'services/opsgenie.md'
+      - Pinglet: 'services/pinglet.md'
       - Pushbullet: 'services/pushbullet.md'
       - Pushover: 'services/pushover.md'
       - Rocketchat: 'services/rocketchat.md'

--- a/pkg/router/servicemap.go
+++ b/pkg/router/servicemap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containrrr/shoutrrr/pkg/services/mattermost"
 	"github.com/containrrr/shoutrrr/pkg/services/ntfy"
 	"github.com/containrrr/shoutrrr/pkg/services/opsgenie"
+	"github.com/containrrr/shoutrrr/pkg/services/pinglet"
 	"github.com/containrrr/shoutrrr/pkg/services/pushbullet"
 	"github.com/containrrr/shoutrrr/pkg/services/pushover"
 	"github.com/containrrr/shoutrrr/pkg/services/rocketchat"
@@ -38,6 +39,7 @@ var serviceMap = map[string]func() t.Service{
 	"mattermost": func() t.Service { return &mattermost.Service{} },
 	"ntfy":       func() t.Service { return &ntfy.Service{} },
 	"opsgenie":   func() t.Service { return &opsgenie.Service{} },
+	"pinglet":    func() t.Service { return &pinglet.Service{} },
 	"pushbullet": func() t.Service { return &pushbullet.Service{} },
 	"pushover":   func() t.Service { return &pushover.Service{} },
 	"rocketchat": func() t.Service { return &rocketchat.Service{} },

--- a/pkg/services/pinglet/pinglet.go
+++ b/pkg/services/pinglet/pinglet.go
@@ -1,0 +1,128 @@
+// Package pinglet implements Pinglet as a shoutrrr service
+package pinglet
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/containrrr/shoutrrr/internal/meta"
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/services/standard"
+	"github.com/containrrr/shoutrrr/pkg/types"
+	"github.com/containrrr/shoutrrr/pkg/util/jsonclient"
+)
+
+// Pinglet renders at most 3 badges per notification, and rejects over-length
+// keys/values outright, so they are truncated client-side to keep the
+// notification deliverable.
+const (
+	maxBadgeCount    = 3
+	maxBadgeKeyLen   = 24
+	maxBadgeValueLen = 32
+	maxDataKeyLen    = 64
+	maxDataValueLen  = 256
+)
+
+// Service sends notifications to Pinglet
+type Service struct {
+	standard.Standard
+	config *Config
+	pkr    format.PropKeyResolver
+}
+
+// Send a notification message to Pinglet
+func (service *Service) Send(message string, params *types.Params) error {
+	config := service.config
+
+	if err := service.pkr.UpdateConfigFromParams(config, params); err != nil {
+		return err
+	}
+
+	if err := service.sendAPI(config, message); err != nil {
+		return fmt.Errorf("failed to send pinglet notification: %w", err)
+	}
+
+	return nil
+}
+
+// Initialize loads ServiceConfig from configURL and sets logger for this Service
+func (service *Service) Initialize(configURL *url.URL, logger types.StdLogger) error {
+	service.Logger.SetLogger(logger)
+	service.config = &Config{}
+	service.pkr = format.NewPropKeyResolver(service.config)
+
+	_ = service.pkr.SetDefaultProps(service.config)
+
+	return service.config.setURL(&service.pkr, configURL)
+}
+
+func (service *Service) sendAPI(config *Config, message string) error {
+	response := apiResponse{}
+	payload := pushPayload{
+		Message:  message,
+		Title:    config.Title,
+		Priority: config.Priority.String(),
+		Badges:   service.truncatedBadges(config),
+		Data:     service.truncatedData(config),
+	}
+
+	jsonClient := jsonclient.NewClient()
+	headers := jsonClient.Headers()
+	headers.Set("User-Agent", "shoutrrr/"+meta.Version)
+	headers.Set("Authorization", "Bearer "+config.Token)
+
+	if err := jsonClient.Post(config.GetAPIURL(), &payload, &response); err != nil {
+		if jsonClient.ErrorResponse(err, &response) {
+			// apiResponse implements Error
+			return &response
+		}
+		return err
+	}
+
+	return nil
+}
+
+// truncatedBadges returns at most maxBadgeCount badges with keys and values
+// truncated to the lengths accepted by the Pinglet API
+func (service *Service) truncatedBadges(config *Config) map[string]string {
+	if len(config.Badges) == 0 {
+		return nil
+	}
+
+	badges := make(map[string]string, maxBadgeCount)
+	for key, value := range config.Badges {
+		if len(badges) >= maxBadgeCount {
+			service.Logger.Logf("Pinglet renders at most %d badges; additional entries were ignored.", maxBadgeCount)
+			break
+		}
+		if len(key) > maxBadgeKeyLen || len(value) > maxBadgeValueLen {
+			service.Logger.Logf("Pinglet badge %q was truncated.", key)
+		}
+		badges[truncate(key, maxBadgeKeyLen)] = truncate(value, maxBadgeValueLen)
+	}
+	return badges
+}
+
+// truncatedData returns metadata with keys and values truncated to the lengths
+// accepted by the Pinglet API
+func (service *Service) truncatedData(config *Config) map[string]string {
+	if len(config.Data) == 0 {
+		return nil
+	}
+
+	data := make(map[string]string, len(config.Data))
+	for key, value := range config.Data {
+		if len(key) > maxDataKeyLen || len(value) > maxDataValueLen {
+			service.Logger.Logf("Pinglet metadata %q was truncated.", key)
+		}
+		data[truncate(key, maxDataKeyLen)] = truncate(value, maxDataValueLen)
+	}
+	return data
+}
+
+func truncate(value string, maxLen int) string {
+	if len(value) > maxLen {
+		return value[:maxLen]
+	}
+	return value
+}

--- a/pkg/services/pinglet/pinglet_config.go
+++ b/pkg/services/pinglet/pinglet_config.go
@@ -1,0 +1,118 @@
+package pinglet
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
+)
+
+var (
+	// ErrTokenMissing is returned when no API key was supplied
+	ErrTokenMissing = errors.New("no API key was supplied")
+
+	// ErrNamespaceTopicMissing is returned when the namespace and/or topic are absent from the URL path
+	ErrNamespaceTopicMissing = errors.New("both a namespace and a topic are required")
+)
+
+// Config for use within the pinglet service
+type Config struct {
+	Title     string            `key:"title"     default:""       desc:"Notification title, optionally set by the sender"`
+	Token     string            `url:"user"                       desc:"Pinglet API key" required:""`
+	Host      string            `url:"host,port"                  desc:"Server hostname (and optionally port)" required:""`
+	Path      string            `url:"path1"     optional:""       desc:"Path prefix, e.g. a reverse-proxy mount point"`
+	Namespace string            `url:"path2"                      desc:"The namespace the topic resides in" required:""`
+	Topic     string            `url:"path3"                      desc:"The topic to publish to" required:""`
+	Scheme    string            `key:"scheme"    default:"https"  desc:"Server protocol, http or https"`
+	Priority  priority          `key:"priority"  default:"normal" desc:"Delivery priority: silent, normal or urgent"`
+	Badges    map[string]string `key:"badges"    optional:""      desc:"Badge pills rendered on the notification card (max 3)"`
+	Data      map[string]string `key:"data"      optional:""      desc:"Metadata key/value pairs shown on the detail sheet"`
+}
+
+// Enums implements types.ServiceConfig
+func (*Config) Enums() map[string]types.EnumFormatter {
+	return map[string]types.EnumFormatter{
+		"Priority": Priority.Enum,
+	}
+}
+
+// GetURL returns a URL representation of it's current field values
+func (config *Config) GetURL() *url.URL {
+	resolver := format.NewPropKeyResolver(config)
+	return config.getURL(&resolver)
+}
+
+// SetURL updates a ServiceConfig from a URL representation of it's field values
+func (config *Config) SetURL(url *url.URL) error {
+	resolver := format.NewPropKeyResolver(config)
+	return config.setURL(&resolver, url)
+}
+
+// GetAPIURL returns the API URL that the notification is posted to
+func (config *Config) GetAPIURL() string {
+	apiURL := url.URL{
+		Scheme: config.Scheme,
+		Host:   config.Host,
+		Path:   config.path(),
+	}
+	return apiURL.String()
+}
+
+// path assembles the request path from the optional prefix, namespace and topic
+func (config *Config) path() string {
+	prefix := ""
+	if config.Path != "" {
+		prefix = "/" + strings.Trim(config.Path, "/")
+	}
+	return prefix + "/" + config.Namespace + "/" + config.Topic
+}
+
+func (config *Config) getURL(resolver types.ConfigQueryResolver) *url.URL {
+	return &url.URL{
+		User:       url.User(config.Token),
+		Host:       config.Host,
+		Scheme:     Scheme,
+		ForceQuery: true,
+		Path:       config.path(),
+		RawQuery:   format.BuildQuery(resolver),
+	}
+}
+
+func (config *Config) setURL(resolver types.ConfigQueryResolver, url *url.URL) error {
+	config.Token = url.User.Username()
+	config.Host = url.Host
+
+	// The last two path segments are the namespace and topic; anything before
+	// them is treated as a path prefix (such as a reverse-proxy mount point).
+	var parts []string
+	for _, segment := range strings.Split(url.Path, "/") {
+		if segment != "" {
+			parts = append(parts, segment)
+		}
+	}
+	if len(parts) < 2 {
+		return ErrNamespaceTopicMissing
+	}
+	config.Topic = parts[len(parts)-1]
+	config.Namespace = parts[len(parts)-2]
+	config.Path = strings.Join(parts[:len(parts)-2], "/")
+
+	for key, vals := range url.Query() {
+		if err := resolver.Set(key, vals[0]); err != nil {
+			return err
+		}
+	}
+
+	if config.Token == "" {
+		return ErrTokenMissing
+	}
+
+	return nil
+}
+
+const (
+	// Scheme is the identifying part of this service's configuration URL
+	Scheme = "pinglet"
+)

--- a/pkg/services/pinglet/pinglet_json.go
+++ b/pkg/services/pinglet/pinglet_json.go
@@ -1,0 +1,22 @@
+package pinglet
+
+import "fmt"
+
+// pushPayload is the JSON body posted to a Pinglet topic
+type pushPayload struct {
+	Message  string            `json:"message"`
+	Title    string            `json:"title,omitempty"`
+	Priority string            `json:"priority"`
+	Badges   map[string]string `json:"badges,omitempty"`
+	Data     map[string]string `json:"data,omitempty"`
+}
+
+// apiResponse is the error body returned by the Pinglet API on a failure
+type apiResponse struct {
+	Code    int64  `json:"code"`
+	Message string `json:"error"`
+}
+
+func (e *apiResponse) Error() string {
+	return fmt.Sprintf("server response: %v (%v)", e.Message, e.Code)
+}

--- a/pkg/services/pinglet/pinglet_priority.go
+++ b/pkg/services/pinglet/pinglet_priority.go
@@ -1,0 +1,37 @@
+package pinglet
+
+import (
+	"github.com/containrrr/shoutrrr/pkg/format"
+	"github.com/containrrr/shoutrrr/pkg/types"
+)
+
+type priority int
+
+type priorityVals struct {
+	Silent priority
+	Normal priority
+	Urgent priority
+	Enum   types.EnumFormatter
+}
+
+// Priority is the enum of delivery priorities supported by Pinglet
+var Priority = &priorityVals{
+	Silent: 0,
+	Normal: 1,
+	Urgent: 2,
+	Enum: format.CreateEnumFormatter(
+		[]string{
+			"silent",
+			"normal",
+			"urgent",
+		}, map[string]int{
+			// Prefix aliases (s => silent, n => normal, u => urgent)
+			"s": 0,
+			"n": 1,
+			"u": 2,
+		}),
+}
+
+func (p priority) String() string {
+	return Priority.Enum.Print(int(p))
+}

--- a/pkg/services/pinglet/pinglet_test.go
+++ b/pkg/services/pinglet/pinglet_test.go
@@ -1,0 +1,259 @@
+package pinglet
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/containrrr/shoutrrr/internal/testutils"
+	"github.com/containrrr/shoutrrr/pkg/format"
+
+	"github.com/jarcoal/httpmock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegaformat "github.com/onsi/gomega/format"
+)
+
+func TestPinglet(t *testing.T) {
+	gomegaformat.CharactersAroundMismatchToInclude = 20
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoutrrr Pinglet Suite")
+}
+
+var (
+	service       *Service = &Service{}
+	envPingletURL *url.URL
+	logger        *log.Logger = testutils.TestLogger()
+	_                         = BeforeSuite(func() {
+		envPingletURL, _ = url.Parse(os.Getenv("SHOUTRRR_PINGLET_URL"))
+	})
+)
+
+var _ = Describe("the pinglet service", func() {
+
+	When("running integration tests", func() {
+		It("should not error out", func() {
+			if envPingletURL.String() == "" {
+				Skip("No integration test ENV URL was set")
+				return
+			}
+
+			configURL := testutils.URLMust(envPingletURL.String())
+			Expect(service.Initialize(configURL, logger)).To(Succeed())
+			Expect(service.Send("This is an integration test message", nil)).To(Succeed())
+		})
+	})
+
+	Describe("the config", func() {
+		When("getting an API URL", func() {
+			It("should return the expected URL", func() {
+				Expect((&Config{
+					Host:      "host:8080",
+					Scheme:    "http",
+					Namespace: "acme",
+					Topic:     "deploys",
+				}).GetAPIURL()).To(Equal("http://host:8080/acme/deploys"))
+			})
+		})
+		When("only required fields are set", func() {
+			It("should set the optional fields to the defaults", func() {
+				serviceURL := testutils.URLMust("pinglet://token@hostname/acme/deploys")
+				Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+
+				Expect(*service.config).To(Equal(Config{
+					Token:     "token",
+					Host:      "hostname",
+					Namespace: "acme",
+					Topic:     "deploys",
+					Scheme:    "https",
+					Priority:  Priority.Normal,
+				}))
+			})
+		})
+		When("parsing the configuration URL", func() {
+			It("should be identical after de-/serialization", func() {
+				testURL := "pinglet://token@example.com:2225/acme/deploys?badges=Host%3Aweb-1&data=region%3Aeu-west&priority=urgent&scheme=http&title=TITLE"
+				config := &Config{}
+				pkr := format.NewPropKeyResolver(config)
+				Expect(config.setURL(&pkr, testutils.URLMust(testURL))).To(Succeed(), "verifying")
+				Expect(config.GetURL().String()).To(Equal(testURL))
+			})
+		})
+		When("no API key is supplied", func() {
+			It("should return an error", func() {
+				serviceURL := testutils.URLMust("pinglet://hostname/acme/deploys")
+				Expect(service.Initialize(serviceURL, logger)).To(HaveOccurred())
+			})
+		})
+		When("the namespace and/or topic are missing", func() {
+			It("should return an error", func() {
+				Expect(service.Initialize(testutils.URLMust("pinglet://token@hostname"), logger)).To(HaveOccurred())
+				Expect(service.Initialize(testutils.URLMust("pinglet://token@hostname/acme"), logger)).To(HaveOccurred())
+			})
+		})
+		When("a path prefix is supplied", func() {
+			It("should treat the last two segments as namespace/topic and keep the prefix", func() {
+				serviceURL := testutils.URLMust("pinglet://token@hostname/prefix/deep/acme/deploys?scheme=http")
+				Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+
+				Expect(service.config.Path).To(Equal("prefix/deep"))
+				Expect(service.config.Namespace).To(Equal("acme"))
+				Expect(service.config.Topic).To(Equal("deploys"))
+				Expect(service.config.GetAPIURL()).To(Equal("http://hostname/prefix/deep/acme/deploys"))
+			})
+			It("should round-trip a prefixed URL", func() {
+				testURL := "pinglet://token@hostname/prefix/acme/deploys?priority=urgent"
+				Expect(service.Initialize(testutils.URLMust(testURL), logger)).To(Succeed())
+				Expect(service.config.GetURL().String()).To(Equal(testURL))
+			})
+		})
+	})
+
+	Describe("the priority", func() {
+		When("parsing priority values", func() {
+			It("should map strings and prefix aliases to the correct value", func() {
+				for input, expected := range map[string]priority{
+					"silent": Priority.Silent,
+					"s":      Priority.Silent,
+					"NORMAL": Priority.Normal,
+					"urgent": Priority.Urgent,
+					"u":      Priority.Urgent,
+				} {
+					serviceURL := testutils.URLMust("pinglet://token@hostname/acme/deploys?priority=" + input)
+					Expect(service.Initialize(serviceURL, logger)).To(Succeed(), input)
+					Expect(service.config.Priority).To(Equal(expected), input)
+				}
+			})
+			It("should error on an unknown priority", func() {
+				serviceURL := testutils.URLMust("pinglet://token@hostname/acme/deploys?priority=invalid")
+				Expect(service.Initialize(serviceURL, logger)).To(HaveOccurred())
+			})
+		})
+	})
+
+	When("sending the push payload", func() {
+		BeforeEach(func() {
+			httpmock.Activate()
+		})
+		AfterEach(func() {
+			httpmock.DeactivateAndReset()
+		})
+
+		It("should not report an error if the server accepts the payload", func() {
+			serviceURL := testutils.URLMust("pinglet://token@hostname/acme/deploys")
+			Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+
+			httpmock.RegisterResponder("POST", service.config.GetAPIURL(), testutils.JSONRespondMust(200, apiResponse{Code: 200, Message: "OK"}))
+
+			Expect(service.Send("Message", nil)).To(Succeed())
+		})
+		It("should send the expected payload", func() {
+			serviceURL := testutils.URLMust("pinglet://mykey@app.pinglet.co.uk/acme/deploys?priority=urgent&badges=CPU:95%25,Host:web-1&data=region:eu-west&title=Hello")
+			Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+
+			var capturedBody pushPayload
+			var capturedAuth string
+			httpmock.RegisterResponder("POST", "https://app.pinglet.co.uk/acme/deploys", func(req *http.Request) (*http.Response, error) {
+				capturedAuth = req.Header.Get("Authorization")
+				Expect(json.NewDecoder(req.Body).Decode(&capturedBody)).To(Succeed())
+				return httpmock.NewStringResponse(200, "{}"), nil
+			})
+
+			Expect(service.Send("It works", nil)).To(Succeed())
+
+			Expect(capturedAuth).To(Equal("Bearer mykey"))
+			Expect(capturedBody.Message).To(Equal("It works"))
+			Expect(capturedBody.Title).To(Equal("Hello"))
+			Expect(capturedBody.Priority).To(Equal("urgent"))
+			Expect(capturedBody.Badges).To(Equal(map[string]string{"CPU": "95%", "Host": "web-1"}))
+			Expect(capturedBody.Data).To(Equal(map[string]string{"region": "eu-west"}))
+		})
+		It("should omit the title, badges and metadata when none are set", func() {
+			serviceURL := testutils.URLMust("pinglet://mykey@hostname/acme/deploys?scheme=http")
+			Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+
+			var capturedBody map[string]interface{}
+			httpmock.RegisterResponder("POST", "http://hostname/acme/deploys", func(req *http.Request) (*http.Response, error) {
+				Expect(json.NewDecoder(req.Body).Decode(&capturedBody)).To(Succeed())
+				return httpmock.NewStringResponse(200, "{}"), nil
+			})
+
+			Expect(service.Send("It works", nil)).To(Succeed())
+
+			Expect(capturedBody).ToNot(HaveKey("title"))
+			Expect(capturedBody).ToNot(HaveKey("badges"))
+			Expect(capturedBody).ToNot(HaveKey("data"))
+			Expect(capturedBody["priority"]).To(Equal("normal"))
+		})
+		It("should not panic if a server error occurs", func() {
+			serviceURL := testutils.URLMust("pinglet://token@hostname/acme/deploys")
+			Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+
+			httpmock.RegisterResponder("POST", service.config.GetAPIURL(), testutils.JSONRespondMust(500, apiResponse{Code: 500, Message: "someone turned off the internet"}))
+
+			Expect(service.Send("Message", nil)).To(HaveOccurred())
+		})
+		It("should not panic if a communication error occurs", func() {
+			httpmock.DeactivateAndReset()
+			serviceURL := testutils.URLMust("pinglet://token@nonresolvablehostname/acme/deploys")
+			Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+			Expect(service.Send("Message", nil)).To(HaveOccurred())
+		})
+	})
+
+	Describe("badge and metadata limits", func() {
+		It("should cap badges at three entries", func() {
+			serviceURL := testutils.URLMust("pinglet://token@hostname/acme/deploys?badges=a:1,b:2,c:3,d:4,e:5")
+			Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+
+			Expect(service.truncatedBadges(service.config)).To(HaveLen(maxBadgeCount))
+		})
+		It("should truncate over-length badge keys/values", func() {
+			serviceURL := testutils.URLMust("pinglet://token@hostname/acme/deploys?badges=" +
+				strings.Repeat("k", 30) + ":" + strings.Repeat("v", 40))
+			Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+
+			Expect(service.truncatedBadges(service.config)).To(Equal(map[string]string{
+				strings.Repeat("k", maxBadgeKeyLen): strings.Repeat("v", maxBadgeValueLen),
+			}))
+		})
+		It("should truncate over-length metadata keys/values", func() {
+			serviceURL := testutils.URLMust("pinglet://token@hostname/acme/deploys?data=" +
+				strings.Repeat("k", 70) + ":" + strings.Repeat("v", 300))
+			Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+
+			Expect(service.truncatedData(service.config)).To(Equal(map[string]string{
+				strings.Repeat("k", maxDataKeyLen): strings.Repeat("v", maxDataValueLen),
+			}))
+		})
+	})
+
+	Describe("the basic service API", func() {
+		Describe("the service config", func() {
+			It("should implement basic service config API methods correctly", func() {
+				testutils.TestConfigGetInvalidQueryValue(&Config{})
+				testutils.TestConfigSetInvalidQueryValue(&Config{}, "pinglet://token@host/acme/deploys?foo=bar")
+
+				testutils.TestConfigGetEnumsCount(&Config{}, 1)
+				testutils.TestConfigGetFieldsCount(&Config{}, 5)
+			})
+		})
+		Describe("the service instance", func() {
+			BeforeEach(func() {
+				httpmock.Activate()
+			})
+			AfterEach(func() {
+				httpmock.DeactivateAndReset()
+			})
+			It("should implement basic service API methods correctly", func() {
+				serviceURL := testutils.URLMust("pinglet://token@hostname/acme/deploys")
+				Expect(service.Initialize(serviceURL, logger)).To(Succeed())
+				testutils.TestServiceSetInvalidParamValue(service, "foo", "bar")
+			})
+		})
+	})
+})


### PR DESCRIPTION
# Add Pinglet notification service

Adds support for [Pinglet](https://pinglet.co.uk), a push notification service that delivers messages to a **topic** within a **namespace** via an authenticated JSON `POST`. Topics are auto-created on first publish. Notifications can optionally carry short "badge" pills and key/value metadata.

## Service details

* **Source:** https://pinglet.co.uk
* **Message format:** plain text
* **Auth:** `Authorization: Bearer <token>`
* **Priorities:** `silent`, `normal` (default), `urgent`
* **Badges:** up to 3 pills rendered on the card (keys/values truncated client-side to what the API accepts)
* **Metadata:** key/value pairs shown on the detail sheet

## URL format

```
pinglet://token@host/namespace/topic
pinglet://token@host:port/namespace/topic
pinglet://token@host/prefix/namespace/topic        # reverse-proxy path prefix
```

The service uses a single `pinglet://` scheme and is secure by default; use `?scheme=http` for an insecure endpoint (matching the existing `ntfy` and `bark` services).

## Examples

```bash
# Simple
shoutrrr send -u "pinglet://apikey@app.pinglet.co.uk/acme/deploys" -m "Message content"

# Priority + badges + metadata, over http
shoutrrr send \
  -u "pinglet://apikey@my.host/acme/deploys?scheme=http&priority=urgent&badges=Host:web-1,CPU:95%25&data=region:eu-west" \
  -m "Build #482 shipped to production"
```

## Parameters

| Key | Required | Description |
|-----|----------|-------------|
| `token` (user) | Yes | Pinglet API key |
| `host[:port]` | Yes | Hostname of your Pinglet instance |
| `namespace` | Yes | Namespace the topic resides in |
| `topic` | Yes | Topic to publish to |
| `scheme` | No | `http` or `https` (default `https`) |
| `priority` | No | `silent`, `normal` (default), `urgent` |
| `badges` | No | Badge pills as `k1:v1,k2:v2` (max 3) |
| `data` | No | Metadata as `k1:v1,k2:v2` |
| `title` | No | Notification title |

Badges and metadata use shoutrrr's map syntax (as in `opsgenie`'s `details`). Note that because Go maps are unordered, when more than 3 badges are supplied the specific 3 that survive the cap is not deterministic.

## Tests

Added `pkg/services/pinglet/pinglet_test.go` (ginkgo suite) covering config defaults, URL de-/serialization round-trips (including a path prefix), priority parsing and aliases, payload construction, badge/metadata caps and truncation, the missing-token / missing-namespace-or-topic error paths, server/connection error handling, and the standard service-compliance checks.

The suite mocks the HTTP layer (`httpmock`) and asserts the request the service produces — endpoint URL, `Bearer` auth header, and JSON payload fields. A live integration test is included but skipped unless `SHOUTRRR_PINGLET_URL` is set, mirroring the other services.

## Documentation

* New `docs/services/pinglet.md`
* Added to the service table in `docs/services/overview.md` and the nav in `mkdocs.yml`

## Checklist

- [x] Unit-tested with mocked HTTP; integration test included (skipped without a live endpoint)
- [x] No commented-out code in this PR
- [x] `gofmt` and `go vet` are clean
- [x] Test coverage added
- [x] Documentation updated
